### PR TITLE
Flexible env var for APC shelf model for Gazebo

### DIFF
--- a/jsk_2015_05_baxter_apc/launch/baxter_world.launch
+++ b/jsk_2015_05_baxter_apc/launch/baxter_world.launch
@@ -8,6 +8,7 @@
   <arg name="gui" default="true"/>
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
+  <arg name="shelf_model_path" default="$(find jsk_2015_apc_common)"/>
 
   <!-- We resume the logic in empty_world.launch, changing the name of the world to be launched -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
@@ -18,6 +19,7 @@
     <arg name="paused" value="$(arg paused)"/>
     <arg name="use_sim_time" value="$(arg use_sim_time)"/>
     <arg name="headless" value="$(arg headless)"/>
+    <env name="GAZEBO_MODEL_PATH" value="$(arg shelf_model_path)" />
   </include>
 
   <!-- Load the URDF into the ROS Parameter Server -->


### PR DESCRIPTION
(既に他の方法が実装済かも知れませんが)

以下図のように Baxter の前に棚を出したい時，折角モデルを `jsk_2015_apc_common` package に置いて頂いてるので，`~/.gazebo` に置き直すとかしたくないと思いました．
![img](https://cloud.githubusercontent.com/assets/9031753/4884512/73862abc-636c-11e4-8d5e-28096bd58032.png)