### PR TITLE
[rosintall] change simulator version and define gazebo_ros branch

### DIFF
--- a/jsk_2015_05_baxter_apc/rosinstall
+++ b/jsk_2015_05_baxter_apc/rosinstall
@@ -34,22 +34,19 @@
     local-name: RethinkRobotics/baxter_tools
     uri: https://github.com/RethinkRobotics/baxter_tools.git
     version: v1.1.0
-
-# Use simplified version urdf
 - git:
     local-name: RethinkRobotics/baxter_common
-    uri: https://github.com/k-okada/baxter_common.git
-    version: fix_simple_urdf_v_1_1_0
-# - git:
-#     local-name: RethinkRobotics/baxter_common
-#     uri: https://github.com/RethinkRobotics/baxter_common.git
-#     version: v1.1.0
-
+    uri: https://github.com/RethinkRobotics/baxter_common.git
+    version: v1.1.0
 - git:
     local-name: RethinkRobotics/baxter_examples
     uri: https://github.com/RethinkRobotics/baxter_examples.git
     version: v1.1.0
 - git:
     local-name: RethinkRobotics/baxter_simulator
-    uri: git@github.com:RethinkRobotics/baxter_simulator.git
-    version: v0.9.0
+    uri: https://github.com/RethinkRobotics/baxter_simulator.git
+    version: v0.9.1.1
+- git:
+    local-name: gazebo_ros_pkgs
+    uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+    version: jade-devel


### PR DESCRIPTION
change baxter_simulator version to v0.9.1.1 for debugging
change baxter_common version to v01.1.0 since fix_simple_urdf_v_1_1_0 is removed 
define gazebo_ros_pkgs for indigo users 