### PR TITLE
[jsk_2016_01_baxter_apc] Fix catkin config of 'jsk_2016_01_baxter_apc'

### DIFF
--- a/jsk_2016_01_baxter_apc/CMakeLists.txt
+++ b/jsk_2016_01_baxter_apc/CMakeLists.txt
@@ -4,7 +4,7 @@ project(jsk_2016_01_baxter_apc)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED roseus)
+find_package(catkin REQUIRED COMPONENTS roseus)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/jsk_2016_01_baxter_apc/package.xml
+++ b/jsk_2016_01_baxter_apc/package.xml
@@ -13,17 +13,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>roseus</build_depend>
   <build_depend>ruby</build_depend> <!-- for erb -->
 
-  <run_depend>gazebo_ros</run_depend>
-  <run_depend>baxter_sim_io</run_depend>
-  <run_depend>baxter_sim_controllers</run_depend>
   <run_depend>baxter_gazebo</run_depend>
+  <run_depend>baxter_sim_controllers</run_depend>
+  <run_depend>baxter_sim_io</run_depend>
+  <run_depend>gazebo_ros</run_depend>
   <run_depend>jsk_2015_05_baxter_apc</run_depend>
   <run_depend>jsk_interactive_marker</run_depend>
-
-  <export>
-    <gazebo_ros gazebo_model_path="${prefix}/models" />
-  </export>
 
 </package>


### PR DESCRIPTION
- Order
- missing build_depend on roseus
- missing 'CONPONENTS'

Modified:
  - jsk_2016_01_baxter_apc/CMakeLists.txt
  - jsk_2016_01_baxter_apc/package.xml