### PR TITLE
[jsk_2016_01_baxter_apc] Handle shell and config files for shared computers

### DIFF
--- a/jsk_2016_01_baxter_apc/CMakeLists.txt
+++ b/jsk_2016_01_baxter_apc/CMakeLists.txt
@@ -101,6 +101,7 @@ catkin_package(
 #  CATKIN_DEPENDS other_catkin_pkg
 #  DEPENDS system_lib
 )
+catkin_add_env_hooks(99.dotfile SHELLS bash zsh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
 
 ###########
 ## Build ##

--- a/jsk_2016_01_baxter_apc/env-hooks/99.dotfile.bash
+++ b/jsk_2016_01_baxter_apc/env-hooks/99.dotfile.bash
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+dotfile () {
+  [ -z $ROS_HOME ] && ros_home=$HOME/.ros || ros_home=$ROS_HOME
+  config_dir=$ros_home/jsk_2016_01_baxter_apc
+  link_files=(.bashrc .zshrc .vimrc .vim .gitconfig)
+  if [ -e $config_dir/current-dotfile ]; then
+    current_user="$(sed -n 1p $config_dir/current-dotfile)"
+    current_shell="$(sed -n 2p $config_dir/current-dotfile)"
+  else
+    mkdir -p $config_dir
+  fi
+  if [ ! $# -eq 2 ]; then
+    echo "Current user: $current_user"
+    echo "Current shell: $current_shell"
+    if [ -e "$current_shell" ]; then
+      exec $current_shell --login
+    fi
+    return 1
+  fi
+  gh_user=$1
+  shell=$2
+  echo "Switching user: $current_user -> $gh_user"
+  echo $gh_user > $config_dir/current-dotfile
+  echo $shell >> $config_dir/current-dotfile
+  for file in $link_files; do
+    if [ -e ~/$file.$gh_user ]; then
+      if [ -L ~/$file -a -d ~/$file ]; then
+        rm ~/$file
+      fi
+      ln -sf ~/$file.$gh_user ~/$file
+      echo "Linked $file -> $file.$gh_user"
+    fi
+  done
+  echo "Logging in as '$user' with '$shell'"
+  exec $shell --login
+}

--- a/jsk_2016_01_baxter_apc/env-hooks/99.dotfile.zsh
+++ b/jsk_2016_01_baxter_apc/env-hooks/99.dotfile.zsh
@@ -1,0 +1,12 @@
+#!/usr/bin/env zsh
+
+# source 99.dotfile.sh from same directory as this file
+_THIS_DIR=$(builtin cd -q "`dirname "$0"`" > /dev/null && pwd)
+if [ -f "$_THIS_DIR/99.dotfile.bash" ]; then
+    source "$_THIS_DIR/99.dotfile.bash"
+else
+    # this is temporary code to avoid error caused by bug in ros/catkin
+    # see https://github.com/jsk-ros-pkg/jsk_common/issues/885
+    source "$_THIS_DIR/etc/catkin/profile.d/99.dotfile.bash"
+fi
+unset _THIS_DIR


### PR DESCRIPTION
Usage:

```
cat ~/.ros/jsk_2016_01_baxter_apc/current-dotfile
dotfile  # set shell with current config
dotfile wkentaro /usr/local/bin/zsh  # set new config
cat ~/.ros/jsk_2016_01_baxter_apc/current-dotfile
```

Modified:
  - jsk_2016_01_baxter_apc/CMakeLists.txt

Added:
  - jsk_2016_01_baxter_apc/env-hooks/99.dotfile.bash
  - jsk_2016_01_baxter_apc/env-hooks/99.dotfile.zsh