### PR TITLE
[jsk_2016_01_baxter_apc] Softkinetic overlook pose

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -467,6 +467,14 @@
       (pushback (send self :ik->bin-entrance arm bin :offset #f(-150 0 0)) avs)
       (send self :angle-vector-sequence avs :fast nil 0 :scale 3.0)
       ))
+  (:move-arm-body->bin-overlook-pose
+    (arm bin)
+    (let (avs)
+      (pushback (send *baxter* :fold-to-keep-object arm) avs)
+      (pushback (send *baxter* :avoid-shelf-pose arm bin) avs)
+      (pushback (send self :ik->bin-entrance arm bin :offset #f(-150 0 -150)) avs)
+      (send self :angle-vector-sequence avs :fast nil 0 :scale 3.0)
+      ))
   (:move-arm-body->order-bin
     (arm)
     (let (avs)


### PR DESCRIPTION
add softkinetic overlook pose method, the position where the camera can see totally inside of a bin.

![softkinetic_overlook_pose](https://cloud.githubusercontent.com/assets/9300063/14722337/0d8d83a6-0846-11e6-9599-c13b6a26c4b5.png)

cc. @yuyu2172 