### PR TITLE
[jsk_apc2016_common] add rbo's code as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule ".travis"]
 	path = .travis
 	url = https://github.com/jsk-ros-pkg/jsk_travis
+[submodule "jsk_apc2016_common/python/jsk_apc2016_common/rbo_segmentation"]
+	path = jsk_apc2016_common/python/jsk_apc2016_common/rbo_segmentation
+	url = https://github.com/yuyu2172/rbo-apc-object-segmentation

--- a/jsk_apc2016_common/CMakeLists.txt
+++ b/jsk_apc2016_common/CMakeLists.txt
@@ -179,7 +179,12 @@ catkin_package(
 
 if(CATKIN_ENABLE_TESTING)
   find_package(roslint REQUIRED)
-  roslint_python()
+  # lint python code
+  file(GLOB_RECURSE _py_files *.py)
+  file(GLOB_RECURSE _exclude_files python/jsk_apc2016_common/rbo_segmentation/*.py)
+  list(REMOVE_ITEM _py_files ${_exclude_files})
+  roslint_python(${_py_files})
   roslint_add_test()
+  # unit tests
   catkin_add_nosetests(python/jsk_apc2016_common/tests)
 endif()


### PR DESCRIPTION
A piece of commit divided from #1332.

Added a submodule that contains a code and dataset distributed on [gitlab](https://gitlab.tubit.tu-berlin.de/rbo-lab/rbo-apc-object-segmentation).

The submodule is imported from a mirrored repository on my github account [https://github.com/yuyu2172/rbo-apc-object-segmentation](https://github.com/yuyu2172/rbo-apc-object-segmentation).
I have decided to mirror the files on my personal page because it was the fastest way to make things work using git submodules.
A downturn of mirroring the file is that the files are managed under my personal page even though all members of APC2016 should have equal privileges.  
