### PR TITLE
[jsk_2016_01_baxter_apc] fixed arduino firmware to disable torque when serial_node.py is killed.

### DIFF
--- a/jsk_2016_01_baxter_apc/firmware/gripper_front_manager_right.ino
+++ b/jsk_2016_01_baxter_apc/firmware/gripper_front_manager_right.ino
@@ -116,8 +116,12 @@ void setup() {
 void loop() {
     float temp_act = 0.0, press_act = 0.0;
     unsigned long int press_cal, temp_cal;
-
-    if (millis() > publisher_timer) {
+    
+    if (!nh.connected()) {
+        servo_torque_msg.data = false;
+        servo_angle_msg.data = 0;
+        myservo.detach();
+    } else if (millis() > publisher_timer) {
         readData();
         temp_cal = calibration_T(temp_raw);
         press_cal = calibration_P(pres_raw);


### PR DESCRIPTION
baxter.launchがkillされた時にサーボのトルクをオフにするようにしました。
どのbranchでも必要な変更だと思ったのでmasterとgripper-v2の両方にPRを送りました。
firmware自体はすでにarduinoに書き込まれているため、両方のbranchでmergeする必要がないと判断された場合には閉じてもらっても構わないです。