### PR TITLE
[jsk_apc2016_common] unzoom returned prediction

### DIFF
--- a/jsk_apc2016_common/python/jsk_apc2016_common/segmentation_in_bin/rbo_segmentation_in_bin.py
+++ b/jsk_apc2016_common/python/jsk_apc2016_common/segmentation_in_bin/rbo_segmentation_in_bin.py
@@ -94,8 +94,10 @@ class RBOSegmentationInBin(object):
                 pickle_mask=False)
 
     def segmentation(self):
-        self.predicted_segment = self.trained_segmenter.predict(
+        zoomed_predicted_segment = self.trained_segmenter.predict(
                 apc_sample=self.apc_sample,
                 desired_object=self.target_object)
+        self.predicted_segment = self.apc_sample.unzoom_segment(
+                zoomed_predicted_segment)
 
         self.predicted_segment = self.predicted_segment.astype('uint8')


### PR DESCRIPTION
Previously, the image returned by RBO's segmentation algorithm zoomed into mask of a bin.
I fixed it to unzoom from the bin.


#### before
![prediction](https://cloud.githubusercontent.com/assets/2062128/14976736/3a4325ca-1149-11e6-932e-0a4c1cde38b8.png)


#### after
![prediction](https://cloud.githubusercontent.com/assets/2062128/14976656/88c54dfa-1148-11e6-8e8e-751693f73bd4.png)

What the returned segment look like with rgb image on background.
![color_prediction](https://cloud.githubusercontent.com/assets/2062128/14976628/4b9c6990-1148-11e6-8541-10bd18889cf2.png)
