### PR TITLE
[jsk_2016_01_baxter_apc] adjust lifting of objects when gripper is straight

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -434,9 +434,12 @@
       ;; lift object
       (ros::ros-info "[:try-to-pick-object] arm:~a lift the object" arm)
       (if (eq arm :rarm)
-        (if (< sign_y 0)
-          (send self :gripper-servo-off arm)))
-      (send self :angle-vector (send *baxter* arm :move-end-pos #f(0 0 80) :local) 3000)
+        (cond ((< sign_y 0)
+               (send self :gripper-servo-off arm)
+               (send self :angle-vector (send *baxter* arm :move-end-pos #f(0 0 20) :world) 3000))
+              (t
+                (send self :angle-vector (send *baxter* arm :move-end-pos #f(0 0 80) :local) 3000)))
+        (send self :angle-vector (send *baxter* arm :move-end-pos #f(0 0 80) :local) 3000))
       (send self :wait-interpolation)
     graspingp))
   (:pick-object


### PR DESCRIPTION
グリッパー関節が曲がっていない時は、グリッパーのローカル座標系のz軸方向にグリッパーを動かすと、物品を持ち上げるのではなく引き出す方向にグリッパーを動かすことになる。今までは、物品を持ち上げる部分のコードがグリッパー関節が曲がっているときと共通だったので、物品を引き出していた。
これを修正し、引き出す方向ではなく、持ち上げる方向に動かすためのPR。
この変更により、binの入口近くにある物品にグリッパー関節を伸ばしてアプローチした場合に、グリッパーを引きすぎてIKを解いたときにそれまでと連続性が低い姿勢がでることがあるという問題( #1394 の実験中にBin eで発生)も同時に解決する。