### PR TITLE
[jsk_apc2016_common] add cpp message synchronizer

### DIFF
--- a/jsk_apc2016_common/CMakeLists.txt
+++ b/jsk_apc2016_common/CMakeLists.txt
@@ -5,10 +5,13 @@ project(jsk_apc2016_common)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+    roscpp
     geometry_msgs
     message_generation
     std_msgs
     jsk_recognition_msgs
+    sensor_msgs
+    message_filters
 )
 
 ## System dependencies are found with CMake's conventions
@@ -50,6 +53,7 @@ add_message_files(
   FILES
   BinInfo.msg
   BinInfoArray.msg
+  SegmentationInBinSync.msg
   )
 
 ## Generate services in the 'srv' folder
@@ -72,6 +76,7 @@ add_message_files(
    std_msgs  # Or other packages containing msgs
    jsk_recognition_msgs
    geometry_msgs
+   sensor_msgs
 )
 
 ################################################
@@ -105,10 +110,13 @@ add_message_files(
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   CATKIN_DEPENDS 
+  roscpp
   message_runtime
   std_msgs 
   geometry_msgs 
   jsk_recognition_msgs
+  message_filters
+  sensor_msgs
 )
 
 ###########
@@ -117,7 +125,9 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-# include_directories(include)
+include_directories(include
+  ${catkin_INCLUDE_DIRS} 
+  )
 
 ## Declare a C++ library
 # add_library(jsk_apc2016_common
@@ -129,17 +139,21 @@ catkin_package(
 ## either from message generation or dynamic reconfigure
 # add_dependencies(jsk_apc2016_common ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
+
 ## Declare a C++ executable
 # add_executable(jsk_apc2016_common_node src/jsk_apc2016_common_node.cpp)
+add_executable(rbo_topic_synchronizer src/rbo_topic_synchronizer.cpp)
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
 # add_dependencies(jsk_apc2016_common_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(rbo_topic_synchronizer ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
 # target_link_libraries(jsk_apc2016_common_node
 #   ${catkin_LIBRARIES}
 # )
+target_link_libraries(rbo_topic_synchronizer ${catkin_LIBRARIES})
 
 #############
 ## Install ##

--- a/jsk_apc2016_common/msg/SegmentationInBinSync.msg
+++ b/jsk_apc2016_common/msg/SegmentationInBinSync.msg
@@ -1,0 +1,3 @@
+sensor_msgs/Image image_color
+sensor_msgs/CameraInfo cam_info
+sensor_msgs/PointCloud2 points

--- a/jsk_apc2016_common/package.xml
+++ b/jsk_apc2016_common/package.xml
@@ -11,15 +11,21 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>roscpp</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>jsk_recognition_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend> 
+  <build_depend>message_filters</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>jsk_recognition_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>message_filters</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>roscpp</run_depend>
 
   <test_depend>roslint</test_depend>
 

--- a/jsk_apc2016_common/src/rbo_topic_synchronizer.cpp
+++ b/jsk_apc2016_common/src/rbo_topic_synchronizer.cpp
@@ -1,0 +1,62 @@
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <jsk_apc2016_common/SegmentationInBinSync.h>
+#include <std_msgs/String.h>
+#include <ros/ros.h>
+#include <sstream>
+
+using namespace sensor_msgs;
+using namespace message_filters;
+
+Image stored_image;
+CameraInfo stored_caminfo;
+PointCloud2 stored_pc;
+
+ros::Publisher pub_;
+
+void callback(const ImageConstPtr& image, const CameraInfoConstPtr& cam_info, const PointCloud2ConstPtr& points)
+{
+    Image image_sent;
+    image_sent = (Image)*image;
+
+    CameraInfo caminfo_sent;
+    caminfo_sent = (CameraInfo) *cam_info;
+
+    PointCloud2 points_sent;
+    points_sent = (PointCloud2) *points;
+
+    jsk_apc2016_common::SegmentationInBinSync sync_data;
+    sync_data.image_color = image_sent;
+    sync_data.cam_info = caminfo_sent;
+    sync_data.points = points_sent;
+    pub_.publish(sync_data);
+    ros::Duration(3).sleep();
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "segmentation_in_bin_sync");
+
+  ros::NodeHandle nh("~");
+
+
+  pub_ = nh.advertise<jsk_apc2016_common::SegmentationInBinSync>("output", 1);
+
+  message_filters::Subscriber<Image> image_sub(nh, "input/image", 1);
+  message_filters::Subscriber<CameraInfo> info_sub(nh, "input/info", 1);
+  message_filters::Subscriber<PointCloud2> point_sub(nh, "input", 1);
+
+  typedef sync_policies::ApproximateTime<Image, CameraInfo, PointCloud2> MySyncPolicy;
+  Synchronizer<MySyncPolicy> sync(MySyncPolicy(100), image_sub, info_sub, point_sub);
+
+  sync.registerCallback(boost::bind(&callback, _1, _2, _3));
+
+  ros::Publisher chatter_pub = nh.advertise<std_msgs::String>("chatter", 1000);
+  ros::spin();
+
+  return 0;
+}


### PR DESCRIPTION
I wrote a cpp code that synchronizes topics and republish a single topics.

This solves issue raised in #1396. Apparently, the problem persisted through debugging because Python is too slow to process topics with large size. 