### PR TITLE
[jsk_2016_01_baxter_apc] avoid collision between body and rarm when pulling out rarm from Bin h

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -551,9 +551,11 @@
       (send bin-coords :rotate (deg2rad (- gripper-angle 90)) :y :world)
       ;; apply offset
       (send bin-coords :translate offset :world)
-      (if (< gripper-angle 45)
+      (if (and (eq arm :rarm) (or (< gripper-angle 45) (eq bin :h)))
         (send *baxter* arm :inverse-kinematics bin-coords
-              :rotation-axis :t  ;; if this is :z, wrist sometimes rotates overly
+              :rotation-axis :t
+              ;; if this is :z when gripper is straight, wrist sometimes rotates overly
+              ;; if this is :z when Bin is h, body and arm collides on pulling out arm
               :revert-if-fail nil)
         (send *baxter* arm :inverse-kinematics bin-coords
               :rotation-axis :z

--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -553,7 +553,7 @@
       (send bin-coords :translate offset :world)
       (if (and (eq arm :rarm) (or (< gripper-angle 45) (eq bin :h)))
         (send *baxter* arm :inverse-kinematics bin-coords
-              :rotation-axis :t
+              :rotation-axis t
               ;; if this is :z when gripper is straight, wrist sometimes rotates overly
               ;; if this is :z when Bin is h, body and arm collides on pulling out arm
               :revert-if-fail nil)


### PR DESCRIPTION
今までは、`(send *ri* :ik->bin-entrance :rarm :h :offset #f(-200 0 -30))`とすると、以下のような姿勢が得られていた。
![screenshot from 2016-05-05 11 03 38](https://cloud.githubusercontent.com/assets/14994939/15036999/a365dcee-12d1-11e6-9e64-4bc2f7fc1215.png)
しかし、この姿勢では、右アームとBaxter本体が下のように干渉している。
![screenshot from 2016-05-05 11 04 53](https://cloud.githubusercontent.com/assets/14994939/15037010/bc7f2e2e-12d1-11e6-832c-8aa69a11ff00.png)
これにより、右グリッパーをBin hから引き出す途中でアームの動きが止まり、その後急に動き出していた。
このPRでは、`:ik->bin-entrance`メソッドにおいて、Binがhの時のみ、グリッパー関節が曲がっていても`:rotation-axis`を`t`にすることにより、`(send *ri* :ik->bin-entrance :rarm :h :offset #f(-200 0 -30))`で以下のような姿勢が得られるようにする。
![screenshot from 2016-05-05 11 08 44](https://cloud.githubusercontent.com/assets/14994939/15037075/697b85f0-12d2-11e6-8ff4-f2c702f93a80.png)
これにより、アームの急な動きが解消されるはずであるが、まだ実機で試していない。