### PR TITLE
[jsk_2016_01_baxter_apc] add revert-if-fail arg for ik->bin-entrance

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -542,7 +542,7 @@
         ))
     )
   (:ik->bin-entrance
-    (arm bin &key (offset #f(0 0 0)))
+    (arm bin &key (offset #f(0 0 0)) (revert-if-fail nil))
     (let (bin-box bin-coords bin-dim-x)
       (setq bin-box (gethash bin _bin-boxes))
       (unless bin-box
@@ -563,7 +563,7 @@
       (send bin-coords :translate offset :world)
       (send *baxter* arm :inverse-kinematics bin-coords
             :rotation-axis :z
-            :revert-if-fail nil)))
+            :revert-if-fail revert-if-fail)))
   (:move-arm-body->bin
     (arm bin)
     (let (avs)

--- a/jsk_2016_01_baxter_apc/test/test-move-arm-to-bin.l
+++ b/jsk_2016_01_baxter_apc/test/test-move-arm-to-bin.l
@@ -17,7 +17,7 @@
       )
     (dolist (arm arm-list)
       (dolist (offset (list #f(-150 0 0) #f(-50 0 0) #f(0 0 0) #f(0 0 -80)))
-        (assert (send *ri* :ik->bin-entrance arm bin :offset offset))
+        (assert (send *ri* :ik->bin-entrance arm bin :offset offset :revert-if-fail t))
         )
       )
     )


### PR DESCRIPTION
Closes #1405
this is for test-move-arm-to-bin