### PR TITLE
[jsk_apc2016_common] changed height value for pixel without depth information

### DIFF
--- a/jsk_apc2016_common/python/jsk_apc2016_common/segmentation_in_bin/rbo_preprocessing.py
+++ b/jsk_apc2016_common/python/jsk_apc2016_common/segmentation_in_bin/rbo_preprocessing.py
@@ -36,6 +36,7 @@ def get_spatial_img(bb_base2camera, cloud, target_bin):
     # scale to mm from m
     dist_img = (dist_img * 1000).astype(np.uint8)
     height_img = (height_img * 2)  # adopting RBO's metric
+    height_img[height_img == 0] = -1
     return dist_img, height_img
 
 


### PR DESCRIPTION
I changed the code to set height data for pixels without depth information to -1.
It follows RBO's convention.