### PR TITLE
[jsk_2016_01_baxter_apc] fixed codes that use rosparam target bin 

### DIFF
--- a/jsk_2016_01_baxter_apc/node_scripts/rbo_segmentation_in_bin_node.py
+++ b/jsk_2016_01_baxter_apc/node_scripts/rbo_segmentation_in_bin_node.py
@@ -38,6 +38,8 @@ class RBOSegmentationInBinNode(ConnectionBasedTransport, RBOSegmentationInBin):
         self.sub .unregister()
 
     def _callback(self, sync):
+        if rospy.get_param('~target_bin_name') not in 'abcdefghijkl':
+            return
         img_msg = sync.image_color
         camera_info = sync.cam_info
         cloud = sync.points

--- a/jsk_2016_01_baxter_apc/node_scripts/rbo_segmentation_in_bin_node.py
+++ b/jsk_2016_01_baxter_apc/node_scripts/rbo_segmentation_in_bin_node.py
@@ -6,21 +6,21 @@ from jsk_apc2016_common.segmentation_in_bin.rbo_segmentation_in_bin\
         import RBOSegmentationInBin
 from jsk_apc2016_common.msg import BinInfoArray, SegmentationInBinSync
 from jsk_topic_tools import ConnectionBasedTransport
+from sensor_msgs.msg import Image
 import rospy
 import tf2_ros
-import message_filters
-from sensor_msgs.msg import Image, CameraInfo
-from sensor_msgs.msg import PointCloud2
 from cv_bridge import CvBridge, CvBridgeError
+import cv2
 
 
 class RBOSegmentationInBinNode(ConnectionBasedTransport, RBOSegmentationInBin):
     def __init__(self):
-        RBOSegmentationInBin.__init__(
-                self,
-                trained_pkl_path=rospy.get_param('~trained_pkl_path'),
-                target_bin_name=rospy.get_param('~target_bin_name'))
+        RBOSegmentationInBin.__init__(self)
+
         ConnectionBasedTransport.__init__(self)
+
+        self.load_trained(rospy.get_param('~trained_pkl_path'))
+
         bin_info_array_msg = rospy.wait_for_message(
                 "~input/bin_info_array", BinInfoArray, timeout=50)
         self.from_bin_info_array(bin_info_array_msg)
@@ -38,26 +38,30 @@ class RBOSegmentationInBinNode(ConnectionBasedTransport, RBOSegmentationInBin):
         self.sub .unregister()
 
     def _callback(self, sync):
+        rospy.loginfo('started')
+
         if rospy.get_param('~target_bin_name') not in 'abcdefghijkl':
             return
         img_msg = sync.image_color
-        camera_info = sync.cam_info
         cloud = sync.points
 
-        rospy.loginfo('started')
         self.target_bin_name = rospy.get_param('~target_bin_name')
+        self.target_object = self.shelf[self.target_bin_name].target
+        self.target_bin = self.shelf[self.target_bin_name]
 
         # mask image
-        self.camera_info = camera_info
+        self.camera_info = sync.cam_info
+        self.camera_model.fromCameraInfo(self.camera_info)
         try:
             img_color = self.bridge.imgmsg_to_cv2(img_msg, "bgr8")
+            img_color = cv2.cvtColor(img_color, cv2.COLOR_BGR2HSV)
         except CvBridgeError as e:
             rospy.logerr('{}'.format(e))
         self.img_color = img_color
 
         # get transform
         camera2bb_base = self.buffer.lookup_transform(
-                target_frame=camera_info.header.frame_id,
+                target_frame=self.camera_info.header.frame_id,
                 source_frame=self.target_bin.bbox.header.frame_id,
                 time=rospy.Time(0),
                 timeout=rospy.Duration(10.0))

--- a/jsk_apc2016_common/python/jsk_apc2016_common/segmentation_in_bin/rbo_segmentation_in_bin.py
+++ b/jsk_apc2016_common/python/jsk_apc2016_common/segmentation_in_bin/rbo_segmentation_in_bin.py
@@ -22,56 +22,14 @@ class RBOSegmentationInBin(object):
         self.dist_img = None
         self._target_bin = None
         self.camera_model = cameramodels.PinholeCameraModel()
-        if 'trained_pkl_path' in kwargs:
-            self.load_trained(kwargs['trained_pkl_path'])
-        if 'target_bin_name' in kwargs:
-            self.target_bin_name = kwargs['target_bin_name']
 
     def from_bin_info_array(self, bin_info_arr):
         for bin_info in bin_info_arr.array:
             self.shelf[bin_info.name] = BinData(bin_info=bin_info)
-        if self.target_bin_name is not None:
-            self.target_bin = self.shelf[self.target_bin_name]
-            self.target_object = self.target_bin.target
 
     def load_trained(self, path):
         with open(path, 'rb') as f:
             self.trained_segmenter = pickle.load(f)
-
-    @property
-    def target_bin_name(self):
-        return self._target_bin_name
-
-    @target_bin_name.setter
-    def target_bin_name(self, target_bin_name):
-        if target_bin_name is not None:
-            self._target_bin_name = target_bin_name
-        if target_bin_name in self.shelf:
-            self.target_object = self.shelf[target_bin_name].target
-            assert self.target_object is not None
-            self.target_bin = self.shelf[target_bin_name]
-
-    @property
-    def camera_info(self):
-        return self._camera_info
-
-    @camera_info.setter
-    def camera_info(self, camera_info):
-        self._camera_info = camera_info
-        if camera_info is not None:
-            self.camera_model.fromCameraInfo(camera_info)
-
-    @property
-    def img_color(self):
-        return self._img_color
-
-    @img_color.setter
-    def img_color(self, img_color):
-        # following RBO's convention that img is loaded as HSV
-        if img_color is not None:
-            self._img_color = cv2.cvtColor(img_color, cv2.COLOR_BGR2HSV)
-        else:
-            self._img_color = None
 
     def set_apc_sample(self):
         assert self.target_object is not None


### PR DESCRIPTION
two fixes
1. Dealt with the case when rosparam 'target_bin' is indeterminate. 
2. initialization of fromBinInfo no longer depends on target_bin