### PR TITLE
[jsk_2016_01_baxter_apc] Don't overload gripper servo when placing object

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -621,6 +621,7 @@
       (pushback (send *baxter* :fold-to-keep-object arm) avs)
       (pushback (send *baxter* :place-object-pose arm) avs)
       (send self :angle-vector-sequence avs)
+      (send self :gripper-servo-off arm)  ;; power off gripper servo not to overload it
       ))
   (:spin-off-by-wrist
     (arm &key (times 10))
@@ -633,6 +634,8 @@
         (pushback (send *baxter* :rotate-wrist arm -10) avs)
         )
       (send self :angle-vector-sequence avs)
+      (send self :gripper-servo-on arm)
+      ;; power on gripper servo as it was powered off in :move-arm-body->order-bin
       ))
   (:move-arm-body->head-view-point
     (arm)


### PR DESCRIPTION
When placing an object in order bin, the gripper servo is always powered on. But if the object is very heavy, gripper servo is overloaded when gripper direction and gravity direction aren't the same while bringing the object.
This PR will fix this using `:gripper-servo-off` in `:move-arm-body->order-bin` and `:gripper-servo-on` in `:spin-off-by-wrist`