### PR TITLE
[jsk_apc2016_common] fix tf_bbox_to_mask slow down

### DIFF
--- a/jsk_apc2016_common/node_scripts/tf_bbox_to_mask.py
+++ b/jsk_apc2016_common/node_scripts/tf_bbox_to_mask.py
@@ -29,7 +29,7 @@ class TFBboxToMask(ConnectionBasedTransport):
         self.pub = self.advertise('~output', Image, queue_size=1)
 
     def subscribe(self):
-        self.sub = rospy.Subscriber('~input', CameraInfo, self._callback)
+        self.sub = rospy.Subscriber('~input', CameraInfo, self._callback, queue_size=3)
 
     def unsubscribe(self):
         self.sub.unregister()


### PR DESCRIPTION
The node publishes mask_msg with old time stamp.
For the time being, I fixed time stamp of the published message.

I think this should be fixed as soon as demo ends.