### PR TITLE
[jsk_apc2016_common] Topic synchronizer for RBO segmentation in bin node

### DIFF
--- a/jsk_apc2016_common/msg/SegmentationInBinSync.msg
+++ b/jsk_apc2016_common/msg/SegmentationInBinSync.msg
@@ -1,3 +1,5 @@
-sensor_msgs/Image image_color
-sensor_msgs/CameraInfo cam_info
-sensor_msgs/PointCloud2 points
+sensor_msgs/Image color_msg
+sensor_msgs/Image dist_msg
+sensor_msgs/Image height_msg
+sensor_msgs/Image mask_msg
+

--- a/jsk_apc2016_common/src/sib_topic_synchronizer.cpp
+++ b/jsk_apc2016_common/src/sib_topic_synchronizer.cpp
@@ -1,62 +1,49 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <sensor_msgs/Image.h>
-#include <sensor_msgs/CameraInfo.h>
-#include <sensor_msgs/PointCloud2.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <jsk_apc2016_common/SegmentationInBinSync.h>
-#include <std_msgs/String.h>
 #include <ros/ros.h>
 #include <sstream>
 
 using namespace sensor_msgs;
 using namespace message_filters;
 
-Image stored_image;
-CameraInfo stored_caminfo;
-PointCloud2 stored_pc;
+Image color_msg;
+Image dist_msg;
+Image height_msg;
+Image mask_msg;
 
 ros::Publisher pub_;
 
-void callback(const ImageConstPtr& image, const CameraInfoConstPtr& cam_info, const PointCloud2ConstPtr& points)
+void callback(const ImageConstPtr& color_msg, const ImageConstPtr& dist_msg, const ImageConstPtr& height_msg, const ImageConstPtr& mask_msg)
 {
-    Image image_sent;
-    image_sent = (Image)*image;
-
-    CameraInfo caminfo_sent;
-    caminfo_sent = (CameraInfo) *cam_info;
-
-    PointCloud2 points_sent;
-    points_sent = (PointCloud2) *points;
-
     jsk_apc2016_common::SegmentationInBinSync sync_data;
-    sync_data.image_color = image_sent;
-    sync_data.cam_info = caminfo_sent;
-    sync_data.points = points_sent;
+    sync_data.color_msg = *color_msg;
+    sync_data.dist_msg  = *dist_msg;
+    sync_data.height_msg = *height_msg;
+    sync_data.mask_msg = *mask_msg;
     pub_.publish(sync_data);
-    ros::Duration(3).sleep();
+    ros::Duration(0.5).sleep();
 }
 
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "segmentation_in_bin_sync");
+    ros::init(argc, argv, "rbo_segmentation_in_bin_sync");
 
-  ros::NodeHandle nh("~");
+    ros::NodeHandle nh("~");
 
+    pub_ = nh.advertise<jsk_apc2016_common::SegmentationInBinSync>("output", 1);
 
-  pub_ = nh.advertise<jsk_apc2016_common::SegmentationInBinSync>("output", 1);
+    message_filters::Subscriber<Image> image_sub(nh, "input/image", /*queue_size*/1);
+    message_filters::Subscriber<Image> dist_sub(nh, "input/dist", 1);
+    message_filters::Subscriber<Image> height_sub(nh, "input/height", 1);
+    message_filters::Subscriber<Image> mask_sub(nh, "input/mask", 1);
 
-  message_filters::Subscriber<Image> image_sub(nh, "input/image", 1);
-  message_filters::Subscriber<CameraInfo> info_sub(nh, "input/info", 1);
-  message_filters::Subscriber<PointCloud2> point_sub(nh, "input", 1);
+    typedef sync_policies::ApproximateTime<Image, Image, Image, Image> MySyncPolicy;
+    Synchronizer<MySyncPolicy> sync(MySyncPolicy(100), image_sub, dist_sub, height_sub, mask_sub);
 
-  typedef sync_policies::ApproximateTime<Image, CameraInfo, PointCloud2> MySyncPolicy;
-  Synchronizer<MySyncPolicy> sync(MySyncPolicy(100), image_sub, info_sub, point_sub);
-
-  sync.registerCallback(boost::bind(&callback, _1, _2, _3));
-
-  ros::Publisher chatter_pub = nh.advertise<std_msgs::String>("chatter", 1000);
-  ros::spin();
-
-  return 0;
+    sync.registerCallback(boost::bind(&callback, _1, _2, _3, _4));
+    ros::spin();
+    return 0;
 }


### PR DESCRIPTION
rbo_segmentation_in_bin node takes 4 images. When message filter is used, it crashes probably due to high workload.

I added synchronizing node written in cpp that publishes a message with 4 images so that python node does not need to use message filter.