### PR TITLE
[jsk_2016_01_baxter_apc] Fix robot self filter for new right gripper

### DIFF
--- a/jsk_2016_01_baxter_apc/config/self_filter.yaml
+++ b/jsk_2016_01_baxter_apc/config/self_filter.yaml
@@ -1,0 +1,47 @@
+min_sensor_dist: .2
+self_see_default_padding: .01
+self_see_default_scale: 1.0
+self_see_links:
+  - name: right_lower_elbow
+    padding: .04
+  - name: right_upper_elbow
+    padding: .04
+  - name: right_lower_forearm
+    padding: .07
+  - name: right_upper_forearm
+    padding: .04
+  - name: right_lower_shoulder
+    padding: .04
+  - name: right_upper_shoulder
+    padding: .04
+  - name: right_wrist
+    padding: .04
+  - name: right_gripper_base
+    padding: .08
+  - name: right_gripper_vacuum_pad
+    padding: .08
+  - name: right_gripper_vacuum_pad_base
+    padding: .08
+  - name: right_softkinetic_camera_link
+    padding: .04
+
+  - name: left_lower_elbow
+    padding: .04
+  - name: left_upper_elbow
+    padding: .04
+  - name: left_lower_forearm
+    padding: .07
+  - name: left_upper_forearm
+    padding: .04
+  - name: left_lower_shoulder
+    padding: .04
+  - name: left_upper_shoulder
+    padding: .04
+  - name: left_wrist
+    padding: .04
+  - name: left_custom_vacuum_link
+    padding: .08
+  - name: left_custom_vacuum_link_base
+    padding: .08
+  - name: left_softkinetic_camera_link
+    padding: .04

--- a/jsk_2016_01_baxter_apc/config/self_filter.yaml
+++ b/jsk_2016_01_baxter_apc/config/self_filter.yaml
@@ -17,11 +17,11 @@ self_see_links:
   - name: right_wrist
     padding: .04
   - name: right_gripper_base
-    padding: .08
+    padding: .01
   - name: right_gripper_vacuum_pad
-    padding: .08
+    padding: .01
   - name: right_gripper_vacuum_pad_base
-    padding: .08
+    padding: .01
   - name: right_softkinetic_camera_link
     padding: .04
 

--- a/jsk_2016_01_baxter_apc/launch/include/self_filter.launch
+++ b/jsk_2016_01_baxter_apc/launch/include/self_filter.launch
@@ -1,0 +1,21 @@
+<launch>
+
+  <arg name="INPUT_CLOUD" />
+  <arg name="OUTPUT_CLOUD" />
+
+  <node name="$(anon self_filter)"
+        pkg="robot_self_filter" type="self_filter"
+        clear_params="true" respawn="true">
+    <remap from="robot_description" to="/robot_description" />
+    <remap from="cloud_in" to="$(arg INPUT_CLOUD)" />
+    <remap from="cloud_out" to="$(arg OUTPUT_CLOUD)" />
+    <rosparam>
+      use_rgb: true
+      keep_organized: true
+      subsample_value: 0.0
+    </rosparam>
+    <rosparam command="load"
+              file="$(find jsk_2016_01_baxter_apc)/config/self_filter.yaml" />
+  </node>
+
+</launch>

--- a/jsk_2016_01_baxter_apc/launch/recognition_in_hand.launch
+++ b/jsk_2016_01_baxter_apc/launch/recognition_in_hand.launch
@@ -45,11 +45,11 @@
 
 
   <!-- self filter -->
-  <include file="$(find jsk_2015_05_baxter_apc)/launch/include/self_filter.launch">
+  <include file="$(find jsk_2016_01_baxter_apc)/launch/include/self_filter.launch">
     <arg name="INPUT_CLOUD" value="extract_indices_left_hand/points" />
     <arg name="OUTPUT_CLOUD" value="extract_indices_left_hand/points_filtered" />
   </include>
-  <include file="$(find jsk_2015_05_baxter_apc)/launch/include/self_filter.launch">
+  <include file="$(find jsk_2016_01_baxter_apc)/launch/include/self_filter.launch">
     <arg name="INPUT_CLOUD" value="extract_indices_right_hand/points" />
     <arg name="OUTPUT_CLOUD" value="extract_indices_right_hand/points_filtered" />
   </include>

--- a/jsk_2016_01_baxter_apc/robots/right_vacuum_gripper.xacro
+++ b/jsk_2016_01_baxter_apc/robots/right_vacuum_gripper.xacro
@@ -1,6 +1,27 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="right_vaccum_gripper">
   <xacro:include filename="$(find jsk_2016_01_baxter_apc)/robots/common_constants.xacro"/>
+  <!--Link bodies-->
+  <xacro:property name="rect_tube_l" value="0.285" />
+  <xacro:property name="rect_tube_h" value="0.06" />
+  <xacro:property name="rect_tube_w" value="0.0952" />
+  <xacro:property name="cyl_tube_x" value="0.005" />
+  <xacro:property name="cyl_tube_z" value="0.038" />
+  <xacro:property name="cyl_tube_r" value="0.018" />
+  <xacro:property name="cyl_tube_l" value="0.107" />
+  <xacro:property name="connection_z" value="-0.00725" />
+  <xacro:property name="connection_r" value="0.03" />
+  <xacro:property name="connection_l" value="0.0905" />
+  <xacro:property name="pad_base_z" value="0.025" />
+  <xacro:property name="pad_base_w" value="0.09" />
+  <xacro:property name="pad_base_h" value="0.038" />
+  <xacro:property name="pad_base_d" value="0.06" />
+  <xacro:property name="pad_r" value="0.026" />
+  <xacro:property name="pad_l" value="0.06" />
+  <xacro:property name="pad_x" value="-0.0005" />
+  <xacro:property name="pad_y" value="0.0085" />
+  <xacro:property name="pad_z" value="0.085" />
+  <!--Joints-->
   <xacro:property name="right_hand_offset_x" value="-0.01" />
   <xacro:property name="right_hand_offset_z" value="0" />
   <xacro:property name="right_gripper_joint_offset_x" value="0.005" />
@@ -17,10 +38,29 @@
         <color rgba="1 1 1 1"/>
       </material>
     </visual>
-    <collision>
+    <!--When using this stl file, robot_self_filter doesn't work-->
+    <!--<collision>
       <origin rpy="${M_PI/2} 0 -${M_PI/2}" xyz="0 0 0"/>
       <geometry>
         <mesh filename="package://jsk_2016_01_baxter_apc/meshes/collision/right_gripper_base.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>-->
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 ${rect_tube_l/2}"/>
+      <geometry>
+        <box size="${rect_tube_h} ${rect_tube_w} ${rect_tube_l}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="${M_PI/2} 0 0" xyz="${cyl_tube_x} -${cyl_tube_l/2} ${cyl_tube_z}"/>
+      <geometry>
+        <cylinder radius="${cyl_tube_r}" length="${cyl_tube_l}"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="${cyl_tube_x} -${cyl_tube_l} ${connection_z}"/>
+      <geometry>
+        <cylinder radius="${connection_r}" length="${connection_l}"/>
       </geometry>
     </collision>
   </link>
@@ -34,10 +74,17 @@
         <color rgba="0.5 0.5 0.5 1"/>
       </material>
     </visual>
-    <collision>
+    <!--When using this stl file, robot_self_filter doesn't work-->
+    <!--<collision>
       <origin rpy="${M_PI/2} 0 -${M_PI/2}" xyz="0 0 0"/>
       <geometry>
         <mesh filename="package://jsk_2016_01_baxter_apc/meshes/collision/right_gripper_vacuum_pad_base.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>-->
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 ${pad_base_z}"/>
+      <geometry>
+        <box size="${pad_base_h} ${pad_base_w} ${pad_base_d}"/>
       </geometry>
     </collision>
   </link>
@@ -51,10 +98,17 @@
         <color rgba="0 1 0 1"/>
       </material>
     </visual>
-    <collision>
+    <!--When using this stl file, robot_self_filter doesn't work-->
+    <!--<collision>
       <origin rpy="${M_PI/2} 0 -${M_PI/2}" xyz="0 0 0"/>
       <geometry>
         <mesh filename="package://jsk_2016_01_baxter_apc/meshes/collision/right_gripper_vacuum_pad.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>-->
+    <collision>
+      <origin rpy="0 0 0" xyz="${pad_x} ${pad_y} ${pad_z}"/>
+      <geometry>
+        <cylinder radius="${pad_r}" length="${pad_l}"/>
       </geometry>
     </collision>
   </link>


### PR DESCRIPTION
Fixes #1456 
Add robot self filter for apc2016 robot model like #1458 
Also, change collision meshes of `right_gripper_base` and `right_gripper_vacuum_pad_base` from STL data to URDF boxes and cylinders.
Visual links
![screenshot from 2016-05-16 11 21 55](https://cloud.githubusercontent.com/assets/14994939/15279746/ada2e582-1b62-11e6-840b-9a968f491ecd.png)
Visual and collision links
![screenshot from 2016-05-16 11 21 32](https://cloud.githubusercontent.com/assets/14994939/15279777/fe69456a-1b62-11e6-8f2e-9df2b7b63612.png)
I'll test this in real robot.