### PR TITLE
[jsk_apc2016_common] removed patch on rbo_sib that fixes time stamp to now

### DIFF
--- a/jsk_apc2016_common/node_scripts/rbo_segmentation_in_bin_node.py
+++ b/jsk_apc2016_common/node_scripts/rbo_segmentation_in_bin_node.py
@@ -83,13 +83,6 @@ class RBOSegmentationInBinNode(ConnectionBasedTransport):
             predict_msg = self.bridge.cv2_to_imgmsg(
                     self.predicted_segment, encoding="mono8")
             predict_msg.header = color_msg.header
-
-            # This is a patch.
-            # Later in the process of SIB, you need to synchronize
-            # the current pointclouds and topics produced using this
-            # topic. The synchronization fails if the timestamp is not
-            # updated to the current time.
-            predict_msg.header.stamp = rospy.Time.now()
             self.img_pub.publish(predict_msg)
         except CvBridgeError as e:
             rospy.logerr('{}'.format(e))


### PR DESCRIPTION
removed patch introduced in #1409.
The patch was necessary because the program ran really slow.