### PR TITLE
[jsk_2016_01_baxter_apc] Fix view-hand-pose to be robust against gripper change

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter.l
@@ -7,11 +7,34 @@
 
 (defclass jsk_2016_01_baxter_apc::baxter-robot
   :super baxter-robot
-  :slots ())
+  :slots (_view-hand-pos))
 (defmethod jsk_2016_01_baxter_apc::baxter-robot
   (:init
     (&rest args)
     (send-super* :init args)
+    ;; initialize _view-hand-pos
+    (setq _view-hand-pos (make-hash-table))
+    (sethash :rarm _view-hand-pos (make-hash-table))
+    (sethash :larm _view-hand-pos (make-hash-table))
+    ;; for larm
+    (sethash :a (gethash :larm _view-hand-pos) #f(785.344 229.224 762.48))
+    (sethash :b (gethash :larm _view-hand-pos) #f(813.742 10.946 828.431))
+    (sethash :d (gethash :larm _view-hand-pos) #f(807.059 275.852 633.668))
+    (sethash :e (gethash :larm _view-hand-pos) #f(770.657 57.875 550.976))
+    (sethash :g (gethash :larm _view-hand-pos) #f(781.985 244.363 368.102))
+    (sethash :h (gethash :larm _view-hand-pos) #f(819.589 13.426 415.42))
+    (sethash :j (gethash :larm _view-hand-pos) #f(811.875 312.473 156.184))
+    (sethash :k (gethash :larm _view-hand-pos) #f(780.791 15.733 137.103))
+    ;; for rarm
+    (sethash :b (gethash :rarm _view-hand-pos) #f(813.742 -10.946 828.431))
+    (sethash :c (gethash :rarm _view-hand-pos) #f(785.344 -180 762.48))
+    (sethash :e (gethash :rarm _view-hand-pos) #f(770.657 -57.875 550.976))
+    (sethash :f (gethash :rarm _view-hand-pos) #f(807.059 -186 633.668))
+    (sethash :h (gethash :rarm _view-hand-pos) #f(819.589 -13.426 415.42))
+    (sethash :i (gethash :rarm _view-hand-pos) #f(781.985 -184 368.102))
+    (sethash :k (gethash :rarm _view-hand-pos) #f(780.791 -15.733 137.103))
+    (sethash :l (gethash :rarm _view-hand-pos) #f(811.875 -180 156.184))
+    ;; pos of :c, :f, :i, :l is not symmetrical to :a, :d, :g, :j because torso can't see
     )
   (:inverse-kinematics
     (target-coords
@@ -68,5 +91,13 @@
       (:j (send self :view-hand-pose-j arm))
       (:k (send self :view-hand-pose-k arm))
       (:l (send self :view-hand-pose-l arm)))
+    (let ((pos (gethash bin (gethash arm _view-hand-pos))))
+      (if pos
+        (send self arm :inverse-kinematics
+              (make-coords :pos pos)
+              :rotation-axis nil
+              :revert-if-fail nil)
+        )
+      )
     )
   )


### PR DESCRIPTION
Fixes #1481 
- Use IK to bring end-coords of arms to good positions to see grasped objects.
- Use hash table to manage above good positions

(ex) `(send *ri* (send *baxter* :view-hand-pose :rarm :c))`
![screenshot from 2016-05-17 19 20 14](https://cloud.githubusercontent.com/assets/14994939/15320047/63b929b0-1c69-11e6-8664-28d6b1400066.png)
