### PR TITLE
[jsk_2016_01_baxter_apc] add proper depends on baxter.urdf in CMakeLists

### DIFF
--- a/jsk_2016_01_baxter_apc/CMakeLists.txt
+++ b/jsk_2016_01_baxter_apc/CMakeLists.txt
@@ -152,6 +152,8 @@ add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/robots/baxter.urdf
 find_package(PkgConfig)
 pkg_check_modules(COLLADA collada-dom>=2.4.4 )
 if ( ${COLLADA_FOUND} )
+  add_custom_target(generate_baxter_urdf ALL DEPENDS ${PROJECT_SOURCE_DIR}/robots/baxter.urdf)
+  add_custom_target(generate_baxter_collada ALL DEPENDS ${PROJECT_SOURCE_DIR}/robots/baxter.dae)
   add_custom_target(generate_baxter_lisp ALL DEPENDS ${PROJECT_SOURCE_DIR}/robots/baxter.l)
 else()
   pkg_check_modules(COLLADA collada-dom)

--- a/jsk_2016_01_baxter_apc/CMakeLists.txt
+++ b/jsk_2016_01_baxter_apc/CMakeLists.txt
@@ -142,7 +142,12 @@ add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/robots/baxter.dae
 add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/robots/baxter.urdf
   COMMAND rosrun xacro xacro baxter.xacro > baxter.urdf
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/robots
-  DEPENDS ${PROJECT_SOURCE_DIR}/robots/baxter.xacro)
+  DEPENDS ${PROJECT_SOURCE_DIR}/robots/baxter.xacro
+          ${PROJECT_SOURCE_DIR}/robots/right_arm_camera.xacro
+          ${PROJECT_SOURCE_DIR}/robots/left_arm_camera.xacro
+          ${PROJECT_SOURCE_DIR}/robots/right_vacuum_gripper.xacro
+          ${PROJECT_SOURCE_DIR}/robots/left_vacuum_gripper.xacro
+          ${PROJECT_SOURCE_DIR}/robots/softkinetic_camera/senz3d.urdf.xacro)
 # get collada-dom version
 find_package(PkgConfig)
 pkg_check_modules(COLLADA collada-dom>=2.4.4 )


### PR DESCRIPTION
with this PR, all xacro's change is deteceted, and baxter.urdf is updated when `catkin build` is executed.