### PR TITLE
revert a part of #1525, that genrate baxter.dae twice

### DIFF
--- a/jsk_2016_01_baxter_apc/CMakeLists.txt
+++ b/jsk_2016_01_baxter_apc/CMakeLists.txt
@@ -152,8 +152,6 @@ add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/robots/baxter.urdf
 find_package(PkgConfig)
 pkg_check_modules(COLLADA collada-dom>=2.4.4)
 if(${COLLADA_FOUND})
-  add_custom_target(generate_baxter_urdf ALL DEPENDS ${PROJECT_SOURCE_DIR}/robots/baxter.urdf)
-  add_custom_target(generate_baxter_collada ALL DEPENDS ${PROJECT_SOURCE_DIR}/robots/baxter.dae)
   add_custom_target(generate_baxter_lisp ALL DEPENDS ${PROJECT_SOURCE_DIR}/robots/baxter.l)
 else()
   pkg_check_modules(COLLADA collada-dom)


### PR DESCRIPTION
see https://s3.amazonaws.com/archive.travis-ci.org/jobs/132534159/log.txt
```
^M^M                                                                                ^M[jsk_2016_01_baxter_apc:make] [  5%] \
Generating /workspace/ros/ws_jsk_apc/src/jsk_apc/jsk_2016_01_baxter_apc/robots/baxter.dae^M^M^M
^M^M                                                                                ^M[jsk_2016_01_baxter_apc:make] [ERROR]\
 [1464090195.203171367]: Error document empty.^M^M^M
^M                                                                                ^M[jsk_2016_01_baxter_apc:make] [ERROR] [\
1464090195.203375662]: failed to open urdf file baxter.urdf^M^M^M
^M^M                                                                                ^M[jsk_2016_01_baxter_apc:make] Segment\
ation fault (core dumped)^M^M^M
^M^M                                                                                ^M[jsk_2016_01_baxter_apc:make] make[2]\
: *** [/workspace/ros/ws_jsk_apc/src/jsk_apc/jsk_2016_01_baxter_apc/robots/baxter.dae] Error 139^M^M^M
^M                                                                                ^M[jsk_2016_01_baxter_apc:make] make[1]: \
*** [CMakeFiles/generate_baxter_lisp.dir/all] Error 2^M^M^M
^M                                                                                ^M[jsk_2016_01_baxter_apc:make] make[1]: \
*** Waiting for unfinished jobs....^M^M^M
^M^M                                                                                ^M[jsk_2016_01_baxter_apc:make] [  5%] \
Generating EusLisp code from baxter_core_msgs/HeadState.msg^M^M^M
^M^M                                                                                ^M[jsk_2016_01_baxter_apc:make] [  5%] \
Generating EusLisp code from baxter_core_msgs/JointCommand.msg^M^M^M
^M^M                                                                                ^M[jsk_2016_01_baxter_apc:make] [  5%] \
Generating /workspace/ros/ws_jsk_apc/src/jsk_apc/jsk_2016_01_baxter_apc/robots/baxter.dae^M^M^M

```