### PR TITLE
[jsk_2016_01_baxter_apc] Simplified version of #1536: Use object_data to publish work_order with APC2016 json

### DIFF
--- a/jsk_2016_01_baxter_apc/launch/main.launch
+++ b/jsk_2016_01_baxter_apc/launch/main.launch
@@ -9,7 +9,10 @@
 
   <!-- work order data -->
   <node pkg="jsk_2016_01_baxter_apc" type="work_order.py" name="work_order" respawn="true">
-    <param name="json" value="$(arg json)" />
+    <rosparam subst_value="true">
+      json: $(arg json)
+      is_apc2016: false
+    </rosparam>
   </node>
 
   <!-- parameter -->

--- a/jsk_2016_01_baxter_apc/node_scripts/work_order.py
+++ b/jsk_2016_01_baxter_apc/node_scripts/work_order.py
@@ -5,36 +5,52 @@ import sys
 import json
 import rospy
 from jsk_2015_05_baxter_apc.msg import WorkOrder, WorkOrderArray
-from jsk_apc2016_common import get_bin_contents, get_work_order, get_object_data
+import jsk_apc2016_common
+from jsk_topic_tools.log_utils import jsk_logwarn
+
+import numpy as np
 
 
-def get_sorted_work_order(json_file, apc2016):
-    """Sort work order to maximize the score"""
-    gripper = rospy.get_param('~gripper', 'gripper2015')
-    bin_contents = get_bin_contents(json_file=json_file)
-    work_order = get_work_order(json_file=json_file)
-    object_data = get_object_data()
-    sorted_bin_list = bin_contents.keys()
+def get_sorted_work_order(json_file, gripper, object_data):
+    """Sort work order to maximize the score.
 
-    def get_graspability(bin_):
-        target_object = work_order[bin_]
-        target_object_data = [data for data in object_data if data['name'] == target_object][0]
-        graspability = target_object_data['graspability'][gripper]
-        return graspability
+    Args:
+      - json_file (str): Json file path.
+      - gripper (str): Gripper name. It must be in object_data.yaml.
+      - object_data (list of dict): Object data that is defined
+            in object_data.yaml.
+    """
+    bin_contents = jsk_apc2016_common.get_bin_contents(json_file=json_file)
+    work_order = jsk_apc2016_common.get_work_order(json_file=json_file)
 
-    if apc2016:
+    # Only for APC2016, we defined graspabilities for each grippers
+    if object_data is not None:
+        sorted_bin_list = bin_contents.keys()
+
+        def get_graspability(bin_):
+            target_object = work_order[bin_]
+            target_object_data = [data for data in object_data
+                                  if data['name'] == target_object][0]
+            graspability = target_object_data['graspability'][gripper]
+            return graspability
+
         sorted_bin_list = sorted(sorted_bin_list, key=get_graspability)
-    sorted_bin_list = sorted(sorted_bin_list, key=lambda bin_: len(bin_contents[bin_]))
+
+    sorted_bin_list = sorted(sorted_bin_list,
+                             key=lambda bin_: len(bin_contents[bin_]))
     sorted_work_order = [(bin_, work_order[bin_]) for bin_ in sorted_bin_list]
     return sorted_work_order
 
 
-def get_work_order_msg(json_file):
-    max_weight = rospy.get_param('~max_weight', -1)
-    apc2016 = rospy.get_param('~apc2016', False)
+def get_work_order_msg(json_file, gripper, object_data=None):
+    """Returns jsk_2015_05_baxter_apc/WorkOrderArray message.
 
-    work_order = get_sorted_work_order(json_file, apc2016)
-    msg = dict(left=WorkOrderArray(), right=WorkOrderArray())
+    Args:
+      - json_file (str): Json file path.
+      - gripper (str): Gripper name. It must be in object_data.yaml.
+      - object_data (list of dict): Object data that is defined
+            in object_data.yaml.
+    """
     abandon_target_objects = [
         'genuine_joe_plastic_stir_sticks',
         'cheezit_big_original',
@@ -46,37 +62,62 @@ def get_work_order_msg(json_file):
         'rolodex_jumbo_pencil_cup',
         'oreo_mega_stuf'
     ]
-    bin_contents = get_bin_contents(json_file=json_file)
-    object_data = get_object_data()
+    # TODO(knorth55): Maybe will use max_weight to skip heavy objects
+    max_weight = np.inf
+
+    work_order = get_sorted_work_order(json_file, gripper, object_data)
+    msg = dict(left=WorkOrderArray(), right=WorkOrderArray())
+    bin_contents = jsk_apc2016_common.get_bin_contents(json_file=json_file)
     for bin_, target_object in work_order:
-        if apc2016:
-            target_object_data = [data for data in object_data if data['name'] == target_object][0]
-            if target_object_data:
-                if target_object_data['weight'] > max_weight and max_weight != -1:
-                    continue
-            else:
+        if object_data is not None:
+            # With object_data, use it for picking decision
+            target_object_data = [data for data in object_data
+                                  if data['name'] == target_object][0]
+            if target_object_data['weight'] > max_weight:
+                # abandon if the target object is too heavy
+                jsk_logwarn(
+                    'Skipping {obj} in {bin} because it is too heavy'
+                    .format(obj=target_object_data['name'], bin=bin_))
                 continue
         else:
+            # Without object_data, use defined blacklist for picking decision
             if target_object in abandon_target_objects:
+                # abandon if it is the target in the bin
+                jsk_logwarn(
+                    'Skipping {obj} in {bin} because it is listed to abandon'
+                    .format(obj=target_object_data['name'], bin=bin_))
                 continue
-            if [bin_object for bin_object in bin_contents[bin_] if bin_object in abandon_bin_objects]:
+            if any(obj in bin_contents[bin_] for obj in abandon_bin_objects):
+                # abandon if it is in the bin
+                jsk_logwarn(
+                    'Skipping {obj} in {bin} because there is objects'
+                    'in {bin} listed to abandon'
+                    .format(obj=target_object_data['name'], bin=bin_))
                 continue
         if len(bin_contents[bin_]) > 5:  # Level3
             continue
+        order = WorkOrder(bin=bin_, object=target_object)
         if bin_ in 'abdegj':
-            msg['left'].array.append(WorkOrder(bin=bin_, object=target_object))
+            msg['left'].array.append(order)
         elif bin_ in 'cfhikl':
-            msg['right'].array.append(WorkOrder(bin=bin_, object=target_object))
+            msg['right'].array.append(order)
+        else:
+            raise ValueError('Unsupported bin name: {0}'.format(bin_))
     return msg
 
 
 def main():
     json_file = rospy.get_param('~json', None)
+    gripper = rospy.get_param('~gripper', 'gripper2015')
+    is_apc2016 = rospy.get_param('~is_apc2016', False)
     if json_file is None:
         rospy.logerr('must set json file path to ~json')
         return
+    object_data = None
+    if is_apc2016:
+        object_data = jsk_apc2016_common.get_object_data()
 
-    msg = get_work_order_msg(json_file)
+    msg = get_work_order_msg(json_file, gripper, object_data)
 
     pub_left = rospy.Publisher('~left_hand',
                                WorkOrderArray,

--- a/jsk_2016_01_baxter_apc/node_scripts/work_order.py
+++ b/jsk_2016_01_baxter_apc/node_scripts/work_order.py
@@ -15,8 +15,6 @@ def get_sorted_work_order(json_file):
     sorted_work_order = []
     work_order = get_work_order(json_file=json_file)
     for bin_, n_contents in sorted(bin_n_contents.items(), key=lambda x: x[1]):
-        if n_contents > 5:  # Level3
-            continue
         sorted_work_order.append((bin_, work_order[bin_]))
     return sorted_work_order
 
@@ -44,6 +42,8 @@ def get_work_order_msg(json_file):
             if bin_object in abandon_bin_objects:
                 bin_contents_bool = True
         if bin_contents_bool:
+            continue
+        if len(bin_contents[bin_]) > 5:  # Level3
             continue
         if bin_ in 'abdegj':
             msg['left'].array.append(WorkOrder(bin=bin_, object=target_object))

--- a/jsk_2016_01_baxter_apc/node_scripts/work_order.py
+++ b/jsk_2016_01_baxter_apc/node_scripts/work_order.py
@@ -109,7 +109,7 @@ def get_work_order_msg(json_file, gripper, object_data=None):
 def main():
     json_file = rospy.get_param('~json', None)
     gripper = rospy.get_param('~gripper', 'gripper2015')
-    is_apc2016 = rospy.get_param('~is_apc2016', False)
+    is_apc2016 = rospy.get_param('~is_apc2016', True)
     if json_file is None:
         rospy.logerr('must set json file path to ~json')
         return

--- a/jsk_2016_01_baxter_apc/test/work_order.test
+++ b/jsk_2016_01_baxter_apc/test/work_order.test
@@ -2,7 +2,9 @@
   <node pkg="jsk_2016_01_baxter_apc" name="work_order" type="work_order.py" >
     <rosparam subst_value="True">
        json: $(find jsk_apc2016_common)/json/pick_layout_1.json
-       rate: 0.1
+       rate: 10
+       apc2016: true
+       max_weight: -1
     </rosparam>
   </node>
 

--- a/jsk_2016_01_baxter_apc/test/work_order.test
+++ b/jsk_2016_01_baxter_apc/test/work_order.test
@@ -3,7 +3,7 @@
     <rosparam subst_value="True">
        json: $(find jsk_apc2016_common)/json/pick_layout_1.json
        rate: 10
-       apc2016: true
+       is_apc2016: true
        gripper: gripper2015
        max_weight: -1
     </rosparam>

--- a/jsk_2016_01_baxter_apc/test/work_order.test
+++ b/jsk_2016_01_baxter_apc/test/work_order.test
@@ -4,6 +4,7 @@
        json: $(find jsk_apc2016_common)/json/pick_layout_1.json
        rate: 10
        apc2016: true
+       gripper: gripper2015
        max_weight: -1
     </rosparam>
   </node>

--- a/jsk_apc2016_common/data/object_data_2016.yaml
+++ b/jsk_apc2016_common/data/object_data_2016.yaml
@@ -1,234 +1,234 @@
 - name: barkely_hide_bones
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 4
 - name: cherokee_easy_tee_shirt
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 1
 - name: clorox_utility_brush
   graspability:
-  - gripper2015: 3
-  # - gripper2016:
+    gripper2015: 3
+  #   gripper2016:
   stock: 1
   weight: 7
 - name: cloud_b_plush_bear
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 3.2
 - name: command_hooks
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 1.6
 - name: cool_shot_glue_sticks
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 2.4
 - name: crayola_24_ct
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 8
 - name: creativity_chenille_stems
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 2
   weight: 4
 - name: dasani_water_bottle
   graspability:
-  - gripper2015: 3
-  # - gripper2016:
+    gripper2015: 3
+  #   gripper2016:
   stock: 2
   weight: 16.9
 - name: dove_beauty_bar
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 4
 - name: dr_browns_bottle_brush
   graspability:
-  - gripper2015: 3
-  # - gripper2016:
+    gripper2015: 3
+  #   gripper2016:
   stock: 1
   weight: 4.2
 - name: easter_turtle_sippy_cup
   graspability:
-  - gripper2015: 3
-  # - gripper2016:
+    gripper2015: 3
+  #   gripper2016:
   stock: 1
   weight: 12
 - name: elmers_washable_no_run_school_glue
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 2
   weight: 4
 - name: expo_dry_erase_board_eraser
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 2
   weight: 0.3
 - name: fiskars_scissors_red
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 1.4
 - name: fitness_gear_3lb_dumbbell
   graspability:
-  - gripper2015: 4
-  # - gripper2016:
+    gripper2015: 4
+  #   gripper2016:
   stock: 1
   weight: 48
 - name: folgers_classic_roast_coffee
   graspability:
-  - gripper2015: 3
-  # - gripper2016:
+    gripper2015: 3
+  #   gripper2016:
   stock: 1
   weight: 11.3
 - name: hanes_tube_socks
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 16
 - name: i_am_a_bunny_book
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 3.2
 - name: jane_eyre_dvd
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 5.12
 - name: kleenex_paper_towels
   graspability:
-  - gripper2015: 3
-  # - gripper2016:
+    gripper2015: 3
+  #   gripper2016:
   stock: 1
   weight: 12.8
 - name: kleenex_tissue_box
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 10
 - name: kyjen_squeakin_eggs_plush_puppies
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 3.2
 - name: laugh_out_loud_joke_book
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 2.9
 - name: oral_b_toothbrush_green
   graspability:
-  - gripper2015: 3
-  # - gripper2016:
+    gripper2015: 3
+  #   gripper2016:
   stock: 1
   weight: 0.5
 - name: oral_b_toothbrush_red
   graspability:
-  - gripper2015: 3
-  # - gripper2016:
+    gripper2015: 3
+  #   gripper2016:
   stock: 1
   weight: 0.5
 - name: peva_shower_curtain_liner
   graspability:
-  - gripper2015: 2
-  # - gripper2016:
+    gripper2015: 2
+  #   gripper2016:
   stock: 1
   weight: 11.8
 - name: platinum_pets_dog_bowl
   graspability:
-  - gripper2015: 2
-  # - gripper2016:
+    gripper2015: 2
+  #   gripper2016:
   stock: 1
   weight: 1.6
 - name: rawlings_baseball
   graspability:
-  - gripper2015: 4
-  # - gripper2016:
+    gripper2015: 4
+  #   gripper2016:
   stock: 1
   weight: 6
 - name: rolodex_jumbo_pencil_cup
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 3.2
 - name: safety_first_outlet_plugs
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 0.3
 - name: scotch_bubble_mailer
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 2
   weight: 1.6
 - name: scotch_duct_tape
   graspability:
-  - gripper2015: 3
-  # - gripper2016:
+    gripper2015: 3
+  #   gripper2016:
   stock: 2
   weight: 2
 - name: soft_white_lightbulb
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 3
 - name: staples_index_cards
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 2
   weight: 3
 - name: ticonderoga_12_pencils
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 2.1
 - name: up_glucose_bottle
   graspability:
-  - gripper2015: 2
-  # - gripper2016:
+    gripper2015: 2
+  #   gripper2016:
   stock: 1
   weight: 11.2
 - name: womens_knit_gloves
   graspability:
-  - gripper2015: 1
-  # - gripper2016:
+    gripper2015: 1
+  #   gripper2016:
   stock: 1
   weight: 2
 - name: woods_extension_cord
   graspability:
-  - gripper2015: 2
-  # - gripper2016:
+    gripper2015: 2
+  #   gripper2016:
   stock: 1
   weight: 6.4


### PR DESCRIPTION
Simplified #1536 

 - Remove apc2016 flag, and use object_data.
 - Get rosparams only in main func.
 - import jsk_apc2016_common
 - Remove no need max_weight currently.
 - ~is_apc2016 True as default.