### PR TITLE
[jsk_2016_01_baxter_apc] Revert a part of #1511 thanks to #1529

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -527,7 +527,7 @@
         (ros::ros-info "[:try-to-pick-object] arm:~a again approach to the object" arm)
         (let ((temp-av (send *baxter* :angle-vector)))
           ;; only if robot can solve IK
-          (if (send *baxter* arm :move-end-pos #f(0 0 -50) :local :rotation-axis :z)
+          (if (send *baxter* arm :move-end-pos #f(0 0 -50) :local)
             (send self :angle-vector (send *baxter* :angle-vector) 3000))
           (send self :wait-interpolation)
           (send self :angle-vector (send *baxter* :angle-vector temp-av) 3000)  ;; revert baxter


### PR DESCRIPTION
Closes #1470 
Thanks to #1529 , #1470 will not occur even though using `:rotation-axis t` in again approach.
Also, thanks to #1512 , the robot only give up approaching again and continue to move if IK fails while approaching again.

So, `:rotation-axis :z` is no longer needed.