### PR TITLE
Use higher trajectory and rotate gripper for entering large object in bin

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -1087,11 +1087,18 @@
  ;; defmethod :select-stow-target-bin
  ;; randomly choose bin for stow task
   (:select-stow-target-bin
-    (arm)
-    (setq i (random 5))
-    (if (eq arm :rarm)
-        (elt '(:c :f :h :i :k :l) i)
-        (elt '(:a :b :d :e :g :j) i)))
+    (arm &key (object-length))
+    (if (and object-length (> object-length 0.2))
+        (progn
+          (setq i (random 2))
+          (if (eq arm :rarm)
+              (elt '(:c :k :l) i)
+              (elt '(:a :b :j) i)))
+        (progn
+          (setq i (random 5))
+          (if (eq arm :rarm)
+              (elt '(:c :f :h :i :k :l) i)
+              (elt '(:a :b :d :e :g :j) i)))))
   )
 
 (defun jsk_2016_01_baxter_apc::baxter-init (&key (ctype :default-controller))

--- a/jsk_2016_01_baxter_apc/euslisp/main-stow.l
+++ b/jsk_2016_01_baxter_apc/euslisp/main-stow.l
@@ -118,20 +118,25 @@
               (if (and object-length (> object-length 0.2))
                 (progn
                   (setq entrance-x-list (list -200 -150 -100 -50 0 150 200))
-                  (setq offset-avoid-bin-top 50))
-                (setq entrance-x-list (list -200 -150 -100 -50 0 150)))
+                  (setq offset-avoid-bin-top 50)
+                  (setq gripper-angle 45))
+                (progn
+                  (setq entrance-x-list (list -200 -150 -100 -50 0 150))
+                  (setq gripper-angle 90)))
               (send *ri* :angle-vector-sequence
                     (list
                       (send *baxter* :avoid-shelf-pose arm target-bin)
                       (send *ri* :ik->bin-entrance arm target-bin
-                            :offset (float-vector -200 0 offset-avoid-bin-top)))
+                            :offset (float-vector -200 0 offset-avoid-bin-top)
+                            :gripper-angle gripper-angle))
                     :fast nil 0 :scale 5.0)
               (send *ri* :wait-interpolation)
               (setq avs-picked->place-bin
                     (mapcar
                       #'(lambda (x)
                           (send *ri* :ik->bin-entrance arm target-bin
-                                :offset (float-vector x 0 offset-avoid-bin-top)))
+                                :offset (float-vector x 0 offset-avoid-bin-top)
+                                :gripper-angle gripper-angle))
                       entrance-x-list))
               (send *ri* :angle-vector-sequence avs-picked->place-bin :fast nil 0 :scale 5.0)
               (send *ri* :wait-interpolation)

--- a/jsk_2016_01_baxter_apc/euslisp/main-stow.l
+++ b/jsk_2016_01_baxter_apc/euslisp/main-stow.l
@@ -138,8 +138,18 @@
               (send *ri* :stop-grasp arm) ;; release object
               (send *ri* :spin-off-by-wrist arm :times 20)
               (send *ri* :wait-interpolation)
+              (if (and object-length (> object-length 0.2))
+                (setq offset-avoid-bin-top-exit 0)
+                (setq offset-avoid-bin-top-exit offset-avoid-bin-top))
+              (setq avs-place-bin->exit
+                    (mapcar
+                      #'(lambda (x)
+                          (send *ri* :ik->bin-entrance arm target-bin
+                                :offset (float-vector x 0 offset-avoid-bin-top-exit)
+                                :gripper-angle 0))
+                      (reverse entrance-x-list)))
               (send *ri* :angle-vector-sequence
-                    (reverse avs-picked->place-bin)
+                    avs-place-bin->exit
                     :fast nil 0 :scale 5.0)
               (send *ri* :wait-interpolation)
               (send *ri* :angle-vector (send *baxter* :avoid-shelf-pose arm target-bin))

--- a/jsk_2016_01_baxter_apc/euslisp/main-stow.l
+++ b/jsk_2016_01_baxter_apc/euslisp/main-stow.l
@@ -85,7 +85,7 @@
           (ros::set-param (format nil "~a_hand/state" (send *ri* :arm-symbol2str arm)) (symbol2str state)))
         (:set_target_bin
           (ros::ros-info "[main] ~a, ~a" arm state)
-          (setq target-bin (send *ri* :select-stow-target-bin arm))
+          (setq target-bin (send *ri* :select-stow-target-bin arm :object-length object-length))
           (if (send *ri* :check-bin-exist target-bin)
               (progn
                 (ros::set-param (format nil "~a_hand/target_bin" (send *ri* :arm-symbol2str arm)) (symbol2str target-bin))

--- a/jsk_2016_01_baxter_apc/euslisp/main-stow.l
+++ b/jsk_2016_01_baxter_apc/euslisp/main-stow.l
@@ -113,22 +113,25 @@
             (progn
               (ros::ros-info "[main] ~a, ~a" arm state)
               (ros::ros-info "[main] ~a, place object in bin ~a" arm target-bin)
-              (setq hcv (send *ri* :get-val '_hard-coded-variables))
+              (setq offset-avoid-bin-top
+                    (gethash :offset-avoid-bin-top (send *ri* :get-val '_hard-coded-variables)))
+              (if (and object-length (> object-length 0.2))
+                (progn
+                  (setq entrance-x-list (list -200 -150 -100 -50 0 150 200))
+                  (setq offset-avoid-bin-top 50))
+                (setq entrance-x-list (list -200 -150 -100 -50 0 150)))
               (send *ri* :angle-vector-sequence
                     (list
                       (send *baxter* :avoid-shelf-pose arm target-bin)
                       (send *ri* :ik->bin-entrance arm target-bin
-                            :offset (float-vector -200 0 (gethash :offset-avoid-bin-top hcv))))
+                            :offset (float-vector -200 0 offset-avoid-bin-top)))
                     :fast nil 0 :scale 5.0)
               (send *ri* :wait-interpolation)
-              (if (and object-length (> 0.20 object-length))
-                (setq entrance-x-list (list -200 -150 -100 -50 0 150))
-                (setq entrance-x-list (list -200 -150 -100 -50 0 150 200)))
               (setq avs-picked->place-bin
                     (mapcar
                       #'(lambda (x)
                           (send *ri* :ik->bin-entrance arm target-bin
-                                :offset (float-vector x 0 (gethash :offset-avoid-bin-top hcv))))
+                                :offset (float-vector x 0 offset-avoid-bin-top)))
                       entrance-x-list))
               (send *ri* :angle-vector-sequence avs-picked->place-bin :fast nil 0 :scale 5.0)
               (send *ri* :wait-interpolation)


### PR DESCRIPTION
Closes #1676 

When robot grasp large object
- put the object in proper bin
- enter in bin with offset :z +50
- exit from bin with offset :z 0

When exiting from bin
- rotate gripper to 0