### PR TITLE
Install axis_camera from source because of its bug

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -39,6 +39,10 @@
     uri: https://github.com/jsk-ros-pkg/jsk_robot.git
     version: master
 - git:
+    local-name: ros-drivers/axis_camera
+    uri: https://github.com/ros-drivers/axis_camera.git
+    version: 8e17a795120ce97e59506c4228d023247451119e
+- git:
     local-name: ros-drivers/openni2_camera
     uri: https://github.com/ros-drivers/openni2_camera.git
     version: indigo-devel


### PR DESCRIPTION
Reported but not yet released: https://github.com/ros-drivers/axis_camera/issues/46