### PR TITLE
Use wait-interpolation-smooth for objects not to run away from gripper

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -39,6 +39,10 @@
     uri: https://github.com/jsk-ros-pkg/jsk_robot.git
     version: master
 - git:
+    local-name: jsk-ros-pkg/jsk_pr2eus
+    uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+    version: 0.3.4
+- git:
     local-name: ros-drivers/axis_camera
     uri: https://github.com/ros-drivers/axis_camera.git
     version: 8e17a795120ce97e59506c4228d023247451119e

--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -616,7 +616,7 @@
             )
           )
         )
-      (send self :wait-interpolation)
+      (send self :wait-interpolation-smooth 1000)
       ;; start the vacuum gripper after approaching to the object
       (ros::ros-info "[:try-to-pick-object] arm:~a start vacuum gripper" arm)
       (send self :start-grasp arm)


### PR DESCRIPTION
I'll check if this is effective for rawlings_baseball, easter_turtle_sippy_cup, kleenex_tissue_box, soft_white_lightbulb, folgers_classic_roast_coffee and up_glucose_bottle. They easily slide too far when gripper push them.