### PR TITLE
fix broken build

### DIFF
--- a/jsk_2016_01_baxter_apc/package.xml
+++ b/jsk_2016_01_baxter_apc/package.xml
@@ -46,5 +46,6 @@
 
   <test_depend>python-gdown</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>roslint</test_depend>
   <test_depend>jsk_tools</test_depend>
 </package>

--- a/jsk_2016_01_baxter_apc/package.xml
+++ b/jsk_2016_01_baxter_apc/package.xml
@@ -4,10 +4,13 @@
   <version>0.8.0</version>
   <description>Common stacks for Amazon Picking Challenge 2016</description>
 
-  <maintainer email="pazeshun3684@gmail.com">pazeshun</maintainer>
+  <maintainer email="pazeshun3684@gmail.com">Hasegawa Shun</maintainer>
   <maintainer email="kimhc6028@gmail.com">Kim Heecheol</maintainer>
   <maintainer email="shingogo@hotmail.co.jp">Shingo Kitagawa</maintainer>
   <maintainer email="bowofvinderre@gmail.com">Bando Masahiro</maintainer>
+  <maintainer email="www.kentaro.wada@gmail.com">Kentaro Wada</maintainer>
+  <maintainer email="niitani@jsk.imi.i.u-tokyo.ac.jp">Yusuke Niitani</maintainer>
+
 
   <license>BSD</license>
 


### PR DESCRIPTION
deb build is broken and removed from release repositories
see http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__jsk_2016_01_baxter_apc__ubuntu_trusty_amd64__binary/

```
Removed Packages [2]:
- ros-indigo-jsk-2016-01-baxter-apc
- ros-indigo-jsk-apc
```
http://lists.ros.org/pipermail/ros-users/2016-June/070033.html