### PR TITLE
Remove :recognize-objects-in-bin in picking-with-sib.l

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/examples/picking-with-sib.l
+++ b/jsk_2016_01_baxter_apc/euslisp/examples/picking-with-sib.l
@@ -37,11 +37,6 @@
             (send *ri* :arm-symbol2str *arm*))
     (symbol2str *bin*))
 
-  (send *ri* :recognize-objects-in-bin *bin* :stamp (ros::time-now))
-
-  ; (ros::ros-info "Getting solidity rag merge result")
-  ; (send *ri* :recognize-grasp-coords-list *bin* :stamp (ros::time-now))
-
   (cond ((not *use-kinect*)
          (send *ri* :move-arm-body->bin-overlook-pose *arm* *bin*)
          (send *ri* :wait-interpolation)


### PR DESCRIPTION
With this PR, picking-with-sib.l works without kinect head.