### PR TITLE
Set nil instead of list when no object found

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -377,8 +377,8 @@
          (sethash bin _objects-sib-coords obj-coords))
         (t
          (ros::ros-error "[:recognize-objects-segmentation-in-bin] arm: ~a failed to get sib msg" arm)
-         (sethash bin _objects-sib-boxes (list nil))
-         (sethash bin _objects-sib-coords (list nil))))))
+         (sethash bin _objects-sib-boxes nil)
+         (sethash bin _objects-sib-coords nil)))))
   (:recognize-object-in-hand
     (arm &key (stamp (ros::time-now)) (timeout))
     (let* (msg)


### PR DESCRIPTION
#1808 で勘違いをしていました。
要素がnilのみのlistを設定していたのは、https://github.com/start-jsk/jsk_apc/blob/master/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l#L458 やhttps://github.com/start-jsk/jsk_apc/blob/master/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l#L463 で`elt`を使用しており、listでないとエラーが出てくるだろうと思ったからでしたが、`:try-to-pick-object`に入る前のhttps://github.com/start-jsk/jsk_apc/blob/master/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l#L728-L732 で、すでにnilかどうかのチェックができており、listを設定する必要はなかったです。