### PR TITLE
depth register works with explicit arg

### DIFF
--- a/jsk_2016_01_baxter_apc/launch/include/astra_hand.launch
+++ b/jsk_2016_01_baxter_apc/launch/include/astra_hand.launch
@@ -8,6 +8,7 @@
     <arg name="depth_frame_id" value="left_hand_camera_depth_optical_frame" />
     <arg name="device_id" value="#1" />
     <arg name="publish_tf" value="false" />
+    <arg name="depth_registration" value="true" />
   </include>
   <node name="left_hand_camera_rgb_static_tf_publisher"
         pkg="tf" type="static_transform_publisher"
@@ -24,6 +25,7 @@
     <arg name="depth_frame_id" value="right_hand_camera_depth_optical_frame" />
     <arg name="device_id" value="#2" />
     <arg name="publish_tf" value="false" />
+    <arg name="depth_registration" value="true" />
   </include>
   <node name="right_hand_camera_rgb_static_tf_publisher"
         pkg="tf" type="static_transform_publisher"


### PR DESCRIPTION

Without this PR, cameras did not publish depth registered points.

FYI, sheeta is equipped with titan X. It can run all launch files by itself.