### PR TITLE
Publish bin bounding boxes in baxter.launch

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -297,7 +297,7 @@
       (position box-size box-sizes-bak)))
   (:recognize-bin-boxes
     (&key (stamp (ros::time-now)))
-    (let ((box-topic (format nil "publish_bin_bbox/boxes"))
+    (let ((box-topic (format nil "publish_bin_boxes/output"))
           box-msg bin-list)
       (setq box-msg (one-shot-subscribe box-topic
                                         jsk_recognition_msgs::BoundingBoxArray

--- a/jsk_2016_01_baxter_apc/launch/baxter.launch
+++ b/jsk_2016_01_baxter_apc/launch/baxter.launch
@@ -46,7 +46,12 @@
         pkg="jsk_interactive_marker" type="marker_6dof">
     <rosparam command="load" file="$(find jsk_2015_05_baxter_apc)/config/kiva_pod_interactive_marker.yaml" />
   </node>
-
+  <node name="publish_bin_boxes"
+        pkg="jsk_apc2016_common" type="publish_bin_bbox.py">
+    <remap from="~boxes" to="~output" />
+    <rosparam file="$(find jsk_apc2016_common)/config/bin_upper_shelf.yaml" command="load" ns="upper_shelf"/>
+    <rosparam file="$(find jsk_apc2016_common)/config/bin_lower_shelf.yaml" command="load" ns="lower_shelf"/>
+  </node>
 
   <node name="desktop_bg_publisher"
         pkg="jsk_perception" type="image_publisher.py">

--- a/jsk_2016_01_baxter_apc/launch/in_bin_data_collection.launch
+++ b/jsk_2016_01_baxter_apc/launch/in_bin_data_collection.launch
@@ -3,17 +3,10 @@
   <arg name="UPPER_SHELF" value="$(find jsk_apc2016_common)/config/bin_upper_shelf.yaml"/>
   <arg name="LOWER_SHELF" value="$(find jsk_apc2016_common)/config/bin_lower_shelf.yaml"/>
 
-  <node name="publish_bin_bbox"
-        pkg="jsk_apc2016_common" type="publish_bin_bbox.py"
-        output="screen">
-    <rosparam file="$(arg UPPER_SHELF)" command="load" ns="upper_shelf"/>
-    <rosparam file="$(arg LOWER_SHELF)" command="load" ns="lower_shelf"/>
-  </node>
-
   <node name="tf_bbox_to_mask_left_hand"
         pkg="jsk_apc2016_common" type="tf_bbox_to_mask.py">
     <remap from="~input" to="/left_hand_camera/rgb/camera_info"/>
-    <remap from="~input/boxes" to="publish_bin_bbox/boxes"/>
+    <remap from="~input/boxes" to="publish_bin_boxes/output"/>
     <rosparam>
       use_bin_info: false
     </rosparam>

--- a/jsk_2016_01_baxter_apc/launch/main.launch
+++ b/jsk_2016_01_baxter_apc/launch/main.launch
@@ -24,25 +24,13 @@
     </rosparam>
   </node>
 
-  <!-- shelf-->
-  <arg name="UPPER_SHELF" value="$(find jsk_apc2016_common)/config/bin_upper_shelf.yaml"/>
-  <arg name="LOWER_SHELF" value="$(find jsk_apc2016_common)/config/bin_lower_shelf.yaml"/>
-
   <!-- Publish jsk_apc2016_common/BinInfo from json -->
   <node name="publish_bin_info"
         pkg="jsk_apc2016_common" type="publish_bin_info.py"
         output="screen">
     <param name="json" value="$(arg json)"/>
-    <rosparam file="$(arg UPPER_SHELF)" command="load" ns="upper_shelf"/>
-    <rosparam file="$(arg LOWER_SHELF)" command="load" ns="lower_shelf"/>
-  </node>
-
-  <!-- publish bin bbox -->
-  <node name="publish_bin_bbox"
-        pkg="jsk_apc2016_common" type="publish_bin_bbox.py"
-        output="screen">
-    <rosparam file="$(arg UPPER_SHELF)" command="load" ns="upper_shelf"/>
-    <rosparam file="$(arg LOWER_SHELF)" command="load" ns="lower_shelf"/>
+    <rosparam file="$(find jsk_apc2016_common)/config/bin_upper_shelf.yaml" command="load" ns="upper_shelf"/>
+    <rosparam file="$(find jsk_apc2016_common)/config/bin_lower_shelf.yaml" command="load" ns="lower_shelf"/>
   </node>
 
   <!-- publish bin tf -->

--- a/jsk_2016_01_baxter_apc/launch/main_stow.launch
+++ b/jsk_2016_01_baxter_apc/launch/main_stow.launch
@@ -2,18 +2,6 @@
   <arg name="launch_main" default="true" />
   <arg name="json" />
 
-  <!-- shelf-->
-  <arg name="UPPER_SHELF" value="$(find jsk_apc2016_common)/config/bin_upper_shelf.yaml"/>
-  <arg name="LOWER_SHELF" value="$(find jsk_apc2016_common)/config/bin_lower_shelf.yaml"/>
-
-  <!-- Publish jsk_apc2016_common/BinInfo from json -->
-  <node name="publish_bin_bbox"
-        pkg="jsk_apc2016_common" type="publish_bin_bbox.py"
-        output="screen">
-    <rosparam file="$(arg UPPER_SHELF)" command="load" ns="upper_shelf"/>
-    <rosparam file="$(arg LOWER_SHELF)" command="load" ns="lower_shelf"/>
-  </node>
-
   <node pkg="jsk_2016_01_baxter_apc" type="stow_work_order_server.py" name="work_order" respawn="true" output="screen" clear_params="true">
     <rosparam subst_value="true">
         json: $(arg json)

--- a/jsk_2016_01_baxter_apc/test/test_move_arm_to_bin.test
+++ b/jsk_2016_01_baxter_apc/test/test_move_arm_to_bin.test
@@ -2,9 +2,19 @@
 
   <env name="DISPLAY" value="" />
 
-  <node name="rosbag_play"
-      pkg="rosbag" type="play"
-      args="$(find jsk_2016_01_baxter_apc)/test_data/2016-04-30-16-33-54_apc2016-bin-boxes.bag --clock" />
+  <!-- publish /tf of shelf -->
+  <include file="$(find jsk_2015_05_baxter_apc)/launch/include/kiva_pod_state.launch" />
+  <node name="interactive_adjust_kiva_pod"
+        pkg="jsk_interactive_marker" type="marker_6dof">
+    <rosparam command="load" file="$(find jsk_2015_05_baxter_apc)/config/kiva_pod_interactive_marker.yaml" />
+  </node>
+
+  <!-- publish shelf bin boxes -->
+  <node name="publish_bin_boxes"
+        pkg="jsk_apc2016_common" type="publish_bin_boxes.py">
+    <rosparam command="load" file="$(find jsk_apc2016_common)/config/bin_upper_shelf.yaml" ns="upper_shelf" />
+    <rosparam command="load" file="$(find jsk_apc2016_common)/config/bin_lower_shelf.yaml" ns="lower_shelf" />
+  </node>
 
   <test test-name="test_move_arm_to_bin"
         name="test_move_arm_to_bin"


### PR DESCRIPTION
This is useful because we can use baxter-interface.l without main.launch or main_stow.lauch.