### PR TITLE
Remove check_baxter_pkg_version.sh that is not used

### DIFF
--- a/jsk_2016_01_baxter_apc/check_baxter_pkg_version.sh
+++ b/jsk_2016_01_baxter_apc/check_baxter_pkg_version.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-rospack list | grep baxter | cut -d\  -f1 | xargs -t -n1 rosversion
-


### PR DESCRIPTION
You can just run in shell:

```
rospack list | awk '{print $1}' | grep baxter | xargs -t -n1 rosversion
```