### PR TITLE
add simulator.rosinstall

### DIFF
--- a/simulator.rosinstall
+++ b/simulator.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: knorth55/baxter_simulator
+    uri: https://github.com/knorth55/baxter_simulator.git
+    version: gripper-sim


### PR DESCRIPTION
for jsk_apc simulator, you need https://github.com/RethinkRobotics/baxter_simulator/pull/88.
according to PR #1892