### PR TITLE
add gripper_trajectory_server for simulator

### DIFF
--- a/jsk_2016_01_baxter_apc/launch/include/baxter_sim.xml
+++ b/jsk_2016_01_baxter_apc/launch/include/baxter_sim.xml
@@ -109,4 +109,7 @@
         pkg="jsk_2015_05_baxter_apc" type="initialize_baxter.py"
         output="screen" />
 
+  <node name="gripper_trajectory_server"
+        pkg="jsk_2016_01_baxter_apc" type="gripper_trajectory_server" output="screen" />
+
 </launch>


### PR DESCRIPTION
without this node, Baxter in simulator does not move with roseus because of error below.

```
[ERROR] [1478767017.396381972, 20.989000000]: Could not start controller with name left_gripper_controller because no controller with this name exists
[ERROR] [1478767017.396454711, 20.989000000]: Could not start controller with name right_gripper_controller because no controller with this name exists
[ERROR] [1478767017.396497205, 20.989000000]: Failed to switch controllers
[ERROR] [1478767017.396525654, 20.989000000]: Failed to switch controllers
```

this gripper_trajectory_server is a dummy and do nothing for gazebo because gripper joint is not loaded in gazebo.

![gazebo_eus](https://cloud.githubusercontent.com/assets/9300063/20169887/41178854-a76d-11e6-9b8e-fc3862043be1.png)
