### PR TITLE
Add dynamixel-motor package to fc.rosinstall

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -13,7 +13,7 @@
 - git:
     local-name: start-jsk/jsk_apc
     uri: https://github.com/start-jsk/jsk_apc.git
-    version: master
+    version: gripper-v5
 - git:
     local-name: FOR_LATEST_BAXTEREUS/baxter_interface
     uri: https://github.com/wkentaro/baxter_interface.git

--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -38,3 +38,7 @@
     local-name: FOR_SIMULATION/baxter_common
     uri: https://github.com/knorth55/baxter_common.git
     version: if-gripper
+- git:
+    local-name: FOR_GRIPPER_V5/dynamixel_motor
+    uri: https://github.com/pazeshun/dynamixel_motor.git
+    version: gripper-v5-devel


### PR DESCRIPTION
Depends on #1943 
`gripper-v5-devel` branch in pazeshun/dynamixel_motor includes arebgun/dynamixel_motor#67 and arebgun/dynamixel_motor#68. Without those PRs, we can't use Multi-turn mode of Dynamixel motor from dynamixel_motor package. 