### PR TITLE
Add udev rules for gripper-v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Write below in `/etc/udev/rules.d/90-rosserial.rules`:
 SUBSYSTEM=="tty", MODE="0666"
 ```
 
+**Setup DXHUB + gripper-v5(and later)**
+
+```bash
+$ rosrun jsk_2016_01_baxter_apc create_udev_rules
+```
+
 **Setup SSH**
 
 Write below in `~/.ssh/config`:

--- a/jsk_2016_01_baxter_apc/firmware/udev/80-dxhub.rules
+++ b/jsk_2016_01_baxter_apc/firmware/udev/80-dxhub.rules
@@ -1,0 +1,3 @@
+# Create symlink /dev/r_dxhub
+# For now, connection to only one DXHUB is supported
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015" MODE:="0666", SYMLINK+="r_dxhub"

--- a/jsk_2016_01_baxter_apc/launch/include/gripper_dxl_controller.launch
+++ b/jsk_2016_01_baxter_apc/launch/include/gripper_dxl_controller.launch
@@ -6,8 +6,7 @@
         namespace: dxl_manager
         serial_ports:
           port:
-            <!-- FIXME: Port shouldn't be ttyUSB*. Replace this to symlink -->
-            port_name: "/dev/ttyUSB0"
+            port_name: "/dev/r_dxhub"
             baud_rate: 1000000
             min_motor_id: 1
             max_motor_id: 25

--- a/jsk_2016_01_baxter_apc/scripts/create_udev_rules
+++ b/jsk_2016_01_baxter_apc/scripts/create_udev_rules
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo ""
+echo "This script copies a udev rule to /etc to facilitate bringing"
+echo "up the DXHUB usb connection as /dev/r_dxhub and /dev/l_dxhub."
+echo "This may require password."
+echo ""
+
+sudo cp `rospack find jsk_2016_01_baxter_apc`/firmware/udev/80-dxhub.rules /etc/udev/rules.d
+
+echo ""
+echo "Restarting udev"
+echo ""
+sudo service udev reload
+sudo service udev restart


### PR DESCRIPTION
This PR allows the connection between gripper-v5 and PC not to depend on device file number(`/dev/ttyUSB0`...)