### PR TITLE
Don't use right gripper joints to solve IK

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter.l
@@ -42,12 +42,13 @@
       &rest args
       &key link-list (use-gripper nil) (rthre (deg2rad 10))
       &allow-other-keys)
-    ;; if the last lik of link-list is a gripper, remove them
+    ;; if the last link of link-list is in gripper, remove gripper links
     (if (null use-gripper)
-      (when (member (send (car (last link-list)) :name)
-                    (list "right_gripper_vacuum_pad_base"
-                          "left_gripper_vacuum_pad_base") :test #'equal)
-            (setq link-list (butlast link-list))) nil)
+      (cond ((equal (send (car (last link-list)) :name) "right_gripper_pad_with_base")
+             (setq link-list (butlast link-list 2)))
+            ((equal (send (car (last link-list)) :name) "left_gripper_vacuum_pad_base")
+             (setq link-list (butlast link-list))))
+      nil)
     (send-super* :inverse-kinematics target-coords :link-list link-list :rthre rthre
                  args)
     )


### PR DESCRIPTION
* Adjust link name to gripper-v5: `right_gripper_vacuum_pad_base`->`right_gripper_pad_with_base`
* gripper-v5 has two joints, so I removed those two joints from link list