### PR TITLE
update baxter_common repo in fc.rosinstall

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -37,4 +37,4 @@
 - git:
     local-name: FOR_SIMULATION/baxter_common
     uri: https://github.com/knorth55/baxter_common.git
-    version: if-gripper
+    version: jsk_apc


### PR DESCRIPTION
this repo is for jsk_apc.
Make collision head smaller than before.
It makes moveit to solve path successfully.