### PR TITLE
[fc.rosinstall] use jsk_pr2eus unreleased version

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -23,6 +23,10 @@
     uri: https://github.com/jsk-ros-pkg/jsk_robot.git
     version: master
 - git:
+    local-name: FOR_LATEST_BAXTEREUS/jsk_pr2eus
+    uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+    version: master
+- git:
     local-name: FOR_PCL1.8/octomap_mapping
     uri: https://github.com/OctoMap/octomap_mapping.git
     version: indigo-devel


### PR DESCRIPTION
use jsk_pr2eus before released version for moveit!
when 0.4.8 is released, we can remove this from fc.rosinstall