### PR TITLE
Adjust picking-with-sib to current object segmentation

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/examples/picking-with-sib.l
+++ b/jsk_2016_01_baxter_apc/euslisp/examples/picking-with-sib.l
@@ -32,10 +32,48 @@
 
 
 (defun solidity-main ()
-  (ros::set-param
-    (format nil "~a_hand/target_bin"
-            (send *ri* :arm-symbol2str *arm*))
-    (symbol2str *bin*))
+  ;; set target
+  (let ((bins (list :a :b :c :d :e :f :g :h :i :j :k :l))
+        (label-names (ros::get-param (format nil "/~a_hand_camera/label_names" (arm2str *arm*))))
+        order target-obj bin-contents)
+    (setq order (send *ri* :get-certain-work-order *arm* *bin*))
+    (if (null order)
+      (progn
+        ;; work order of *bin* doesn't exist
+        (ros::ros-warn "[solidity-main] could not find work order of ~a" *bin*)
+        (return-from solidity-main nil)
+        )
+      (progn
+        (ros::ros-warn "work-order: ~a" order)
+        ;; get target param
+        (setq target-obj (send order :object))
+        (setq bin-contents (send *ri* :get-bin-contents *bin*))
+        (ros::set-dynparam
+          (format nil "/~a_hand_camera/bbox_array_to_bbox" (arm2str *arm*))
+          (cons "index" (position *bin* bins)))
+        (ros::set-dynparam
+          (format nil "/~a_hand_camera/label_to_mask" (arm2str *arm*))
+          (cons "label_value" (position target-obj label-names :test #'string=)))
+        (send *ri* :set-object-segmentation-candidates
+              :arm *arm*
+              :candidates (mapcar #'(lambda (x) (position x label-names :test #'string=))
+                                  (append (list "background") bin-contents)))
+        (if (send *ri* :check-bin-exist *bin*)
+          (progn
+            (ros::set-param
+              (format nil "~a_hand/target_bin" (arm2str *arm*))
+              (symbol2str *bin*))
+            ;; logging
+            (ros::ros-info-blue "[solidity-main] target-bin: ~a, target-obj: ~a" *bin* target-obj)
+            )
+          (progn
+            (ros::ros-warn "[solidity-main] could not find bin box: ~a" *bin*)
+            (return-from solidity-main nil)
+            )
+          )
+        )
+      )
+    )
 
   (cond ((not *use-kinect*)
          (send *ri* :move-arm-body->bin-overlook-pose *arm* *bin*)

--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -1476,6 +1476,16 @@
       (dotimes (i (- (length orders) 1))
         (when (string= (send (elt orders i) :bin) (send current-order :bin))
           (return-from :get-next-work-order (elt orders (+ i 1)))))))
+  (:get-certain-work-order
+    (arm bin)
+    (let ((orders (send self :get-work-orders arm)))
+      (when (eq (length orders) 0)
+        (ros::ros-error "[:get-certain-work-order] There is no order")
+        (return-from :get-certain-work-order nil))
+      (when (null bin) (return-from :get-certain-work-order (elt orders 0)))
+      (dotimes (i (length orders))
+        (when (string= (send (elt orders i) :bin) (symbol2str bin))
+          (return-from :get-certain-work-order (elt orders i))))))
   (:check-bin-exist
     (bin)
     (if (gethash bin _bin-boxes) t nil))


### PR DESCRIPTION
To follow 2c768428141ee7c9e4ad16f732688f91dc7c145a and 178240324e56606eb98b1dd3e8196d77c3d7abf4