### PR TITLE
Enable to set ik-prepared-poses

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter.l
@@ -8,7 +8,7 @@
 
 (defclass jsk_2016_01_baxter_apc::baxter-robot
   :super baxter-robot
-  :slots (_view-hand-pos))
+  :slots (_view-hand-pos _ik-prepared-poses))
 (defmethod jsk_2016_01_baxter_apc::baxter-robot
   (:init
     (&rest args)
@@ -36,7 +36,15 @@
     (sethash :k (gethash :rarm _view-hand-pos) #f(780.791 -15.733 137.103))
     (sethash :l (gethash :rarm _view-hand-pos) #f(811.875 -180 156.184))
     ;; pos of :c, :f, :i, :l is not symmetrical to :a, :d, :g, :j because torso can't see
+    ;; initialize _ik-prepared-poses
+    (setq _ik-prepared-poses (list :untuck-pose))
     )
+  (:set-ik-prepared-poses
+    (poses)
+    (if (listp poses)
+      (setq _ik-prepared-poses poses))
+    )
+  (:ik-prepared-poses () _ik-prepared-poses)
   (:inverse-kinematics
     (target-coords
       &rest args


### PR DESCRIPTION
### What I did
* Add `:ik-prepared-poses` method to jsk_2016_01_baxter_apc::baxter-robot in order to use the feature in https://github.com/jsk-ros-pkg/jsk_robot/commit/a530df140a9f7dafdc4946da4a0f59e03452831b
* Add `:set-ik-prepared-poses` method to change the return value of `:ik-prepared-poses` in order to set initial pose of IK used when normal IK fails
### Usage
```
14.irteusgl$ send *baxter* :angle-vector av1
#f(0.0 84.7218 11.3176 -100.769 137.239 60.5701 25.7966 34.7697 0.0 -17.7207 -42.6019 132.521 78.9492 -102.309 60.9403 -137.432 0.0)
15.irteusgl$ send *baxter* :ik-prepared-poses
(:untuck-pose)
16.irteusgl$ send *baxter* :rarm :inverse-kinematics ec
; failed for normal ik, starting from relaxed position
; failed for normal ik, try to move arms very slowly
; failed for slow ik, try to start from prepared poses
; starting from prepared pose ':untuck-pose'
#f(0.0 84.7218 11.3176 -100.769 137.239 60.5701 25.7966 34.7697 0.0 16.975 -7.70005 145.461 100.423 21.4429 -89.9227 -50.574 0.0)
17.irteusgl$ send *baxter* :angle-vector av1
#f(0.0 84.7218 11.3176 -100.769 137.239 60.5701 25.7966 34.7697 0.0 -17.7207 -42.6019 132.521 78.9492 -102.309 60.9403 -137.432 0.0)
18.irteusgl$ send *baxter* :set-ik-prepared-poses nil
nil
19.irteusgl$ send *baxter* :rarm :inverse-kinematics ec
; failed for normal ik, starting from relaxed position
; failed for normal ik, try to move arms very slowly
; failed for slow ik, try to start from prepared poses
nil
20.irteusgl$ send *baxter* :angle-vector av1
#f(0.0 84.7218 11.3176 -100.769 137.239 60.5701 25.7966 34.7697 0.0 -17.7207 -42.6019 132.521 78.9492 -102.309 60.9403 -137.432 0.0)
21.irteusgl$ send *baxter* :set-ik-prepared-poses (list :fold-pose-back)
(:fold-pose-back)
22.irteusgl$ send *baxter* :rarm :inverse-kinematics ec
; failed for normal ik, starting from relaxed position
; failed for normal ik, try to move arms very slowly
; failed for slow ik, try to start from prepared poses
; starting from prepared pose ':fold-pose-back'
#f(0.0 84.7218 11.3176 -100.769 137.239 60.5701 25.7966 34.7697 0.0 -2.17063 -27.2064 131.983 100.213 -137.441 79.2606 150.433 0.0)
```