### PR TITLE
Fix rarm endcoords in baxter.yaml

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/publish-end-coords.l
+++ b/jsk_2016_01_baxter_apc/euslisp/publish-end-coords.l
@@ -1,0 +1,14 @@
+;; vim: set ft=lisp:
+(require "package://jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l")
+
+(jsk_2016_01_baxter_apc::baxter-init)
+(send *baxter* :angle-vector (send *ri* :state :potentio-vector))
+(ros::advertise "/rarm_end_coords" geometry_msgs::PoseStamped)
+(unix::sleep 1)
+
+(setq msg (instance geometry_msgs::PoseStamped :init))
+(send msg :header :frame_id "base")
+(send msg :pose (ros::coords->tf-pose (send *baxter* :rarm :end-coords :worldcoords)))
+(send msg :header :stamp (ros::time-now))
+(ros::publish "/rarm_end_coords" msg)
+(exit)

--- a/jsk_2016_01_baxter_apc/euslisp/publish-end-coords.l
+++ b/jsk_2016_01_baxter_apc/euslisp/publish-end-coords.l
@@ -1,14 +1,23 @@
+#!/usr/bin/env roseus
 ;; vim: set ft=lisp:
+
 (require "package://jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l")
 
+(defun publish-end-caords (arm)
+  (send *baxter* :angle-vector (send *ri* :state :potentio-vector))
+  (setq msg (instance geometry_msgs::PoseStamped :init))
+  (send msg :header :frame_id "base")
+  (send msg :pose (ros::coords->tf-pose (send *baxter* arm :end-coords :worldcoords)))
+  (send msg :header :stamp (ros::time-now))
+  (if (eq arm :larm)
+    (ros::publish "/larm_end_coords" msg)
+    (ros::publish "/rarm_end_coords" msg)
+    )
+  )
+
 (jsk_2016_01_baxter_apc::baxter-init)
-(send *baxter* :angle-vector (send *ri* :state :potentio-vector))
+(ros::advertise "/larm_end_coords" geometry_msgs::PoseStamped)
 (ros::advertise "/rarm_end_coords" geometry_msgs::PoseStamped)
 (unix::sleep 1)
-
-(setq msg (instance geometry_msgs::PoseStamped :init))
-(send msg :header :frame_id "base")
-(send msg :pose (ros::coords->tf-pose (send *baxter* :rarm :end-coords :worldcoords)))
-(send msg :header :stamp (ros::time-now))
-(ros::publish "/rarm_end_coords" msg)
-(exit)
+(publish-end-caords :larm)
+(publish-end-caords :rarm)

--- a/jsk_2016_01_baxter_apc/robots/baxter.yaml
+++ b/jsk_2016_01_baxter_apc/robots/baxter.yaml
@@ -66,7 +66,7 @@ larm-end-coords:
   rotate : [0, -1, 0, 180]
 rarm-end-coords:
   parent : right_gripper_vacuum_pad
-  translate : [-0.0005, 0.0085, 0.085]
+  translate : [-0.0005, 0, 0.085]
   rotate : [0, -1, 0, 180]
 head-end-coords:
   parent : head_camera


### PR DESCRIPTION
I'm wondering why translate values in baxter.yaml are different
among rarm and larm