### PR TITLE
Depends at test time on jsk_2016_01_baxter_apc

### DIFF
--- a/jsk_arc2017_baxter/CMakeLists.txt
+++ b/jsk_arc2017_baxter/CMakeLists.txt
@@ -39,7 +39,7 @@ catkin_package()
 
 if(CATKIN_ENABLE_TESTING)
   find_package(jsk_tools REQUIRED)
-  find_package(jsk_2016_01_baxter_apc REQUIRED)
+  find_package(jsk_apc2016_common REQUIRED)
   if(${jsk_tools_VERSION} VERSION_GREATER 2.0.13)
     jsk_tools_add_shell_test(COMMAND "rosrun jsk_apc2016_common euslint ${PROJECT_SOURCE_DIR}")
   endif()

--- a/jsk_arc2017_baxter/package.xml
+++ b/jsk_arc2017_baxter/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>jsk_2015_05_baxter_apc</run_depend>
-  <run_depend>jsk_2016_01_baxter_apc</run_depend>
   <run_depend>jsk_apc2015_common</run_depend>
   <run_depend>jsk_apc2016_common</run_depend>
   <run_depend>jsk_arc2017_common</run_depend>
@@ -31,6 +30,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>xacro</run_depend>
 
+  <test_depend>jsk_2016_01_baxter_apc</test_depend>
   <test_depend>jsk_tools</test_depend>
 
   <export>

--- a/jsk_arc2017_baxter/package.xml
+++ b/jsk_arc2017_baxter/package.xml
@@ -14,7 +14,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>jsk_apc2016_common</build_depend>
+
   <run_depend>jsk_2015_05_baxter_apc</run_depend>
+  <run_depend>jsk_2016_01_baxter_apc</run_depend>
   <run_depend>jsk_apc2015_common</run_depend>
   <run_depend>jsk_apc2016_common</run_depend>
   <run_depend>jsk_arc2017_common</run_depend>
@@ -30,7 +33,6 @@
   <run_depend>rospy</run_depend>
   <run_depend>xacro</run_depend>
 
-  <test_depend>jsk_2016_01_baxter_apc</test_depend>
   <test_depend>jsk_tools</test_depend>
 
   <export>


### PR DESCRIPTION
Without this change, we have error of failed finding of jsk_2016_01_baxter_apc at `find_package` in test block.