### PR TITLE
remove unused arg : left_first

### DIFF
--- a/jsk_arc2017_baxter/launch/setup/setup_for_pick.launch
+++ b/jsk_arc2017_baxter/launch/setup/setup_for_pick.launch
@@ -1,11 +1,7 @@
 <launch>
 
-  <arg name="left_first" default="true" />
-
   <!-- Launch hand mounted astra cameras. -->
-  <include file="$(find jsk_2016_01_baxter_apc)/launch/include/astra_hand.launch">
-    <arg name="left_first" value="$(arg left_first)" />
-  </include>
+  <include file="$(find jsk_2016_01_baxter_apc)/launch/include/astra_hand.launch" />
 
   <!-- Launch pipeline for 3D object segmentation. -->
   <!-- for left hand camera -->


### PR DESCRIPTION
最新のsetup_for_pick.launchを立ち上げると、以下のようなエラーが出ました。
```
unused args [left_first] for include of [/home/naoya/Projects/jsk_apc/src/start-jsk/jsk_apc/jsk_2016_01_baxter_apc/launch/include/astra_hand.launch]
The traceback for the exception was written to the log file
```

astra_hand.launchでleft_firstが不要になったのにincludeでargを渡していたことが原因だと思うので、left_firstを消しました。