### PR TITLE
Fix torque limit of prismatic joint in gripper-v5

### DIFF
--- a/jsk_2016_01_baxter_apc/config/right_gripper_v5/dxl_controllers.yaml
+++ b/jsk_2016_01_baxter_apc/config/right_gripper_v5/dxl_controllers.yaml
@@ -5,7 +5,7 @@ prismatic_joint_controller:
     type: CalibRequiredJointController
   joint_name: right_gripper_prismatic_joint_motor
   joint_speed: 2.0
-  joint_torque_limit: 0.4
+  joint_torque_limit: 0.3
   calib_speed: 1.0
   calib_torque_limit: 0.3
   detect_limit_load: 0.17


### PR DESCRIPTION
I found this change is needed for safety in Robomech 2017 demo.