### PR TITLE
fix default-controller not to set head-controller twice

### DIFF
--- a/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l
@@ -108,13 +108,13 @@
     (send-super :larm-controller)
     (send self :lgripper-controller)))
   ;; Overwrite super class's :default-controller
-  (:default-controller
-    () ;; larm-controller include head-controller
-    (append
-      (send self :larm-controller)
-      (send self :rarm-controller)
-      ;;(send self :head-controller)
-      ))
+  (:default-controller ()
+   (append
+    (send-super :head-controller)
+    (send-super :rarm-controller)
+    (send self :rgripper-controller)
+    (send-super :larm-controller)
+    (send self :lgripper-controller)))
   ;; Rename super class's :rarm-controller to :rarm-no-gripper-controller
   (:rarm-no-gripper-controller ()
    (send-super :rarm-controller))


### PR DESCRIPTION
This causes `(send *ri* :wait-interpolation)` does not finish when you use `:default-controller`.