### PR TITLE
Pass chainermodel name to correct param

### DIFF
--- a/jsk_apc2016_common/launch/object_segmentation_3d.launch
+++ b/jsk_apc2016_common/launch/object_segmentation_3d.launch
@@ -19,6 +19,7 @@
       gpu: $(arg GPU)
       backend: $(arg BACKEND)
       model_name: $(arg MODEL_NAME)
+      model_h5: $(arg MODEL_FILE)
       model_file: $(arg MODEL_FILE)
     </rosparam>
     <remap from="~target_names" to="label_names" />


### PR DESCRIPTION
The name of chainer model should be passed to `model_h5` param.
https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_perception/node_scripts/fcn_object_segmentation.py#L58