### PR TITLE
add jsk_gui_msgs to jsk_apc_common

### DIFF
--- a/jsk_apc2016_common/CMakeLists.txt
+++ b/jsk_apc2016_common/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
     message_generation
     std_msgs
     jsk_data
+    jsk_gui_msgs
     jsk_recognition_msgs
     sensor_msgs
     message_filters
@@ -80,6 +81,7 @@ add_service_files(
 generate_messages(
   DEPENDENCIES
   std_msgs  # Or other packages containing msgs
+  jsk_gui_msgs # jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l and jsk_arc2017_baxter/euslisp/lib/arc-interface.l
   jsk_recognition_msgs
   geometry_msgs
   sensor_msgs

--- a/jsk_apc2016_common/package.xml
+++ b/jsk_apc2016_common/package.xml
@@ -19,6 +19,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>jsk_data</build_depend>
+  <build_depend>jsk_gui_msgs</build_depend>
   <build_depend>jsk_recognition_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend> 
   <build_depend>message_filters</build_depend>
@@ -36,6 +37,7 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>jsk_data</run_depend>
+  <run_depend>jsk_gui_msgs</run_depend>
   <run_depend>jsk_recognition_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_filters</run_depend>


### PR DESCRIPTION
someone need to compile jsk_gui_msgs

```
jsk_apc$ grep jsk_gui_msgs -r *
jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxterrgv5-interface.l:                                "/rviz/yes_no_button" (instance jsk_gui_msgs::YesNoRequest)) :yes))
jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/baxter-interface.l:                                "/rviz/yes_no_button" (instance jsk_gui_msgs::YesNoRequest)) :yes))
jsk_arc2017_baxter/euslisp/lib/arc-interface.l:                                "/rviz/yes_no_button" (instance jsk_gui_msgs::YesNoRequest)) :yes)))
```