### PR TITLE
add calibration yaml files of astra mini stereo

### DIFF
--- a/jsk_2016_01_baxter_apc/data/astra/stereo_left_astra_mini_8_rgb.yaml
+++ b/jsk_2016_01_baxter_apc/data/astra/stereo_left_astra_mini_8_rgb.yaml
@@ -1,6 +1,6 @@
 image_width: 640
 image_height: 480
-camera_name: narrow_stereo/left
+camera_name: "rgb_Orbbec_Orbbec    "
 camera_matrix:
   rows: 3
   cols: 3

--- a/jsk_2016_01_baxter_apc/data/astra/stereo_left_astra_mini_8_rgb.yaml
+++ b/jsk_2016_01_baxter_apc/data/astra/stereo_left_astra_mini_8_rgb.yaml
@@ -1,0 +1,20 @@
+image_width: 640
+image_height: 480
+camera_name: narrow_stereo/left
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [509.015381, 0.000000, 320.675346, 0.000000, 508.683267, 236.130072, 0.000000, 0.000000, 1.000000]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [0.007313, -0.068372, -0.002248, 0.001679, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [0.999627, 0.007759, 0.026199, -0.007718, 0.999969, -0.001661, -0.026211, 0.001459, 0.999655]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [514.030690, 0.000000, 302.063255, 0.000000, 0.000000, 514.030690, 236.707602, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000]

--- a/jsk_2016_01_baxter_apc/data/astra/stereo_right_astra_mini_10_rgb.yaml
+++ b/jsk_2016_01_baxter_apc/data/astra/stereo_right_astra_mini_10_rgb.yaml
@@ -1,0 +1,20 @@
+image_width: 640
+image_height: 480
+camera_name: narrow_stereo/right
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [509.835452, 0.000000, 319.797425, 0.000000, 509.039942, 239.475551, 0.000000, 0.000000, 1.000000]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [0.018452, -0.092523, -0.001073, 0.000166, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [0.999619, 0.007213, 0.026635, -0.007254, 0.999973, 0.001464, -0.026623, -0.001656, 0.999644]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [514.030690, 0.000000, 302.063255, -44.044691, 0.000000, 514.030690, 236.707602, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000]

--- a/jsk_2016_01_baxter_apc/data/astra/stereo_right_astra_mini_10_rgb.yaml
+++ b/jsk_2016_01_baxter_apc/data/astra/stereo_right_astra_mini_10_rgb.yaml
@@ -1,6 +1,6 @@
 image_width: 640
 image_height: 480
-camera_name: narrow_stereo/right
+camera_name: "rgb_Orbbec_Orbbec    "
 camera_matrix:
   rows: 3
   cols: 3


### PR DESCRIPTION
`stereo_left_astra_mini_8_rgb.yaml` means TEPRA code such as "ASTRA MINI S 2017/04/11 8/10"
`stereo_right_astra_mini_10_rgb.yaml` means TEPRA code such as "ASTRA MINI S 2017/04/11 10/10"