### PR TITLE
Use smach state machine in pick-main.l

### DIFF
--- a/jsk_arc2017_baxter/CMakeLists.txt
+++ b/jsk_arc2017_baxter/CMakeLists.txt
@@ -1,13 +1,26 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_arc2017_baxter)
 
-find_package(catkin REQUIRED COMPONENTS roseus)
+find_package(catkin REQUIRED COMPONENTS
+    message_generation
+    roseus
+)
 
 ################################################
 ## Declare ROS messages, services and actions ##
 ################################################
 
-# XXX
+add_service_files(
+    FILES
+    UpdateState.srv
+    GetState.srv
+    CheckCanStart.srv
+)
+
+generate_messages(
+    DEPENDENCIES
+    std_msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -19,7 +32,10 @@ find_package(catkin REQUIRED COMPONENTS roseus)
 ## catkin specific configuration ##
 ###################################
 
-catkin_package()
+catkin_package(
+    CATKIN_DEPENDS
+    message_runtime
+)
 
 ###########
 ## Build ##

--- a/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
@@ -64,21 +64,6 @@
                (setq cube (send self :bbox->cube (gethash bin bin-boxes-)))
                (sethash bin bin-movable-regions-
                         (send self :cube->movable-region cube :offset offset))))))
-  (:need-to-wait-opposite-arm
-    (arm state)
-    (let (opposite-state)
-      (setq opposite-state
-            (str2symbol (ros::get-param
-                          (format nil "~a_hand/state"
-                                  (arm2str (opposite-arm arm))))))
-      (if (eq state :wait_for_opposite_arm_start_picking)
-        (null (or (eq opposite-state :recognize_objects_in_bin)
-                  (eq opposite-state :wait_for_user_input)))
-        (or (eq opposite-state :recognize_objects_in_bin)
-            (eq opposite-state :pick_object)
-            (eq opposite-state :verify_object)
-            (eq opposite-state :set_target_cardboard)
-            (eq opposite-state :return_object)))))
   (:get-work-orders
     (arm)
     (let (msg)
@@ -423,7 +408,27 @@
           :fast (send *ri* :get-arm-controller arm) 0))
   (:send-av
     (&optional (tm 3000) (ctype nil))
-    (send *ri* :angle-vector (send *baxter* :angle-vector) tm ctype)))
+    (send *ri* :angle-vector (send *baxter* :angle-vector) tm ctype))
+  (:check-can-start (arm start-state wait-state)
+    (let ((service-name
+           (format nil "/state_server/~a_hand/check_can_start" (arm2str arm)))
+          req can-start)
+      (ros::wait-for-service service-name)
+      (setq req (instance jsk_arc2017_baxter::CheckCanStartRequest :init))
+      (send req :start_state (symbol2str start-state))
+      (send req :wait_state (symbol2str wait-state))
+      (setq can-start
+            (send (ros::service-call service-name req) :can_start))
+      can-start))
+  (:update-state (arm state)
+    (let ((service-name
+           (format nil "/state_server/~a_hand/update_state" (arm2str arm)))
+          req updated)
+      (ros::wait-for-service service-name)
+      (setq req (instance jsk_arc2017_baxter::UpdateStateRequest :init))
+      (send req :state (symbol2str state))
+      (setq updated (send (ros::service-call service-name req) :updated))
+      updated)))
 
 (defun jsk_arc2017_baxter::arc-init (&key (ctype :default-controller) (moveit nil))
   (let (mvit-env mvit-rb)

--- a/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
@@ -1,0 +1,209 @@
+#!/usr/bin/env roseus
+
+(require "package://jsk_2015_05_baxter_apc/euslisp/jsk_2015_05_baxter_apc/util.l")
+(require "package://jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc/util.l")
+(require "package://jsk_arc2017_baxter/euslisp/lib/baxter.l")
+(require "package://jsk_arc2017_baxter/euslisp/lib/baxter-interface.l")
+(require "package://jsk_arc2017_baxter/euslisp/lib/arc-interface.l")
+
+(ros::load-ros-manifest "jsk_arc2017_baxter")
+
+(unless (find-package "JSK_ARC2017_BAXTER")
+  (make-package "JSK_ARC2017_BAXTER"))
+
+(defclass jsk_arc2017_baxter::pick-interface
+  :super jsk_arc2017_baxter::arc-interface
+  :slots (bin-contents
+          bins
+          dropped
+          fail-count
+          graspingp
+          label-names
+          order
+          target-bin
+          target-cardboard
+          target-obj))
+
+(defmethod jsk_arc2017_baxter::pick-interface
+  (:init ()
+    (send-super :init)
+    (setq fail-count 0)
+    (setq bins (list :a :b :c)))
+  (:recognize-bin-boxes ()
+    (ros::ros-info "[main] recognizing shelf bin boxes")
+    (send-super :recognize-bin-boxes :stamp (ros::time-now))
+    (ros::ros-info "[main] recognizing cardboard boxes")
+    (send self :set-movable-region-for-bin :offset (list 80 120 0)))
+  (:wait-for-user-input (arm)
+    (let (can-start)
+      (ros::ros-info "[:wait-for-user-input] wait for user input to start: ~a" arm)
+      (ros::wait-for-service "/rviz/yes_no_button")
+      (setq can-start
+            (send (ros::service-call "/rviz/yes_no_button"
+                                     (instance jsk_gui_msgs::YesNoRequest))
+                  :yes))
+      (ros::ros-info "[:wait-for-user-input] received user input: ~a" arm)
+      can-start))
+  (:set-target (arm)
+    (setq label-names
+          (ros::get-param (format nil "/~a_hand_camera/label_names"
+                                  (arm2str arm))))
+    (setq order (send self :get-next-work-order arm order))
+    (unless order (return-from :set-target nil))
+    (ros::ros-warn "next-work-order: ~a" (send order :item))
+    ;; get target param
+    (setq target-bin (str2symbol (send order :bin)))
+    (setq target-obj (send order :item))
+    (setq target-cardboard (str2symbol (send order :box)))
+    (setq bin-contents (send self :get-bin-contents target-bin))
+    (unless (send self :check-bin-exist target-bin)
+      (ros::ros-warn "[~a] [main] could not find bin box: ~a" (ros::get-name) target-bin)
+      (return-from :set-target nil))
+    (ros::set-param
+      (format nil "~a_hand/target_object" (arm2str arm)) target-obj)
+    (ros::set-dynparam
+      (format nil "/~a_hand_camera/bbox_array_to_bbox" (arm2str arm))
+      (cons "index" (position target-bin bins)))
+    (ros::set-dynparam
+      (format nil "/~a_hand_camera/label_to_mask" (arm2str arm))
+      (cons "label_value" (position target-obj label-names :test #'string=)))
+    (send self :set-object-segmentation-candidates arm
+      (mapcar #'(lambda (x) (position x label-names :test #'string=))
+              (append (list "__background__") bin-contents (list "__shelf__"))))
+    (ros::set-param
+      (format nil "~a_hand/target_bin" (arm2str arm))
+      (symbol2str target-bin))
+    ;; logging
+    (ros::ros-info-blue "[~a] [main] :set-target, target-bin: ~a, target-obj: ~a" (ros::get-name) target-bin target-obj)
+    t)
+  (:recognize-object (arm &key (trial-times 10))
+    (let (is-recognized recognition-count)
+      (send self :add-shelf-scene)
+      (send self :add-cardboard-scene arm)
+      (send *baxter* :head_pan :joint-angle (if (eq arm :larm) -80 80))
+      (send *ri* :angle-vector-raw (send *baxter* :angle-vector) 3000 :head-controller 0)
+      (send *ri* :wait-interpolation)
+      (ros::ros-info "[main] Recognizing objects in bin ~a" target-bin)
+      (send self :move-arm-body->bin-overlook-pose arm target-bin)
+      (send *ri* :wait-interpolation)
+      (setq recognition-count 1)
+      (while (null (or (> recognition-count trial-times) is-recognized))
+        (setq is-recognized
+              (send self :recognize-objects-in-bin arm :stamp (ros::time-now)))
+        (setq recognition-count (incf recognition-count)))
+      is-recognized))
+  (:return-from-recognize-objects (arm)
+    (ros::ros-info "[main] arm: ~a, failed to recognize object ~a" arm target-obj)
+    (send *ri* :angle-vector-sequence
+          (list (send *baxter* :fold-to-keep-object arm)
+                (send *baxter* :fold-pose-back arm))
+          :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
+    (send *ri* :wait-interpolation)
+    (send self :delete-shelf-scene)
+    (send self :delete-cardboard-scene arm))
+  (:pick-object (arm)
+    (send self :delete-shelf-scene)
+    (send self :pick-object-in-bin arm target-bin
+          :n-trial 2
+          :n-trial-same-pos 1
+          :do-stop-grasp nil)
+    (send *ri* :angle-vector
+          (send self :ik->bin-center arm target-bin
+                :offset #f(0 0 300) :rotation-axis :z :use-gripper t)
+          3000 (send *ri* :get-arm-controller arm) 0)
+    (send *ri* :wait-interpolation)
+    (setq graspingp (send *ri* :graspingp arm))
+    (ros::ros-info "[main] arm: ~a graspingp: ~a" arm graspingp)
+    graspingp)
+  (:return-from-pick-object (arm)
+    (send *ri* :stop-grasp arm)
+    (send *ri* :angle-vector-sequence
+          (list (send *baxter* :avoid-shelf-pose arm (if (eq arm :larm) :d :f))
+                (send *baxter* :fold-pose-back arm))
+          :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
+    (send *ri* :wait-interpolation))
+  (:verify-object (arm)
+    (setq fail-count 0)
+    ;; TODO: in-hand verification
+    ;; TODO:   target-obj = in-hand object  -> :set_target_cardboard
+    ;; TODO:   target-obj != in-hand object -> :return_object
+    target-obj)
+  (:check-fail-count (arm)
+    (setq fail-count (incf fail-count))
+    (ros::ros-info "[main] arm: ~a, picking fail count: ~a" arm fail-count)
+    (> fail-count 1))
+  (:set-target-cardboard (arm)
+    (if (eq target-cardboard :shelf)
+      (progn
+        (ros::ros-info "[main] blacklisted object, return to shelf")
+        nil)
+      (progn
+        (ros::set-param (format nil "~a_hand/target_box" (arm2str arm)) (symbol2str target-cardboard))
+        ;; logging
+        (ros::ros-info "[main] target-cardboard: ~a" target-cardboard)
+        t)))
+  (:return-object (arm)
+    (send *ri* :angle-vector
+          (send self :ik->bin-center arm target-bin
+                :offset #f(0 0 0) :coords-pitch 0
+                :rotation-axis :z
+                :use-gripper t)
+          :fast (send *ri* :get-arm-controller arm) 0 :scale 3.0)
+    (send *ri* :wait-interpolation)
+    (send *ri* :stop-grasp arm)
+    (send self :spin-off-by-wrist 5)
+    (send *ri* :wait-interpolation)
+    (ros::ros-info "[main] ~a, return object in shelf" arm)
+    (send self :add-shelf-scene)
+    (send *ri* :fold-pose-back arm)
+    (send *ri* :wait-interpolation))
+  (:place-object (arm)
+    (let (dropped)
+      (ros::ros-info "[main] ~a, place object in bin ~a" arm target-cardboard)
+      (send self :add-shelf-scene)
+      (send *baxter* :head_pan :joint-angle (if (eq arm :larm) 80 -80))
+      (send *ri* :angle-vector
+            (send self :ik->cardboard-entrance arm target-cardboard
+                  :offset #f(0 0 300) :rotation-axis :z :use-gripper t)
+            4000 (send *ri* :get-arm-controller arm) 0)
+      (send *ri* :wait-interpolation)
+      (setq dropped (not (send *ri* :graspingp arm)))
+      (if dropped
+        (progn
+          (ros::ros-error "[main] arm ~a: dropped object" arm)
+          (send *ri* :stop-grasp arm))
+        (progn
+          (ros::ros-info-green "[main] arm ~a: place object ~a in cardboard ~a" arm target-obj target-cardboard)
+          (send self :delete-cardboard-scene arm)
+          (send *ri* :angle-vector-raw (send *baxter* arm :move-end-pos #f(0 0 -300) :world)
+                2000 (send *ri* :get-arm-controller arm) 0)
+          (send *ri* :wait-interpolation)
+          (send *ri* :stop-grasp arm) ;; release object
+          (send self :spin-off-by-wrist arm :times 10)
+          (send *ri* :wait-interpolation)
+          (send *ri* :angle-vector-raw (send *baxter* arm :move-end-pos #f(0 0 300) :world)
+                1000 (send *ri* :get-arm-controller arm) 0)
+          (send *ri* :wait-interpolation)
+          (send self :add-cardboard-scene arm)))))
+  (:return-from-place-object (arm)
+    (send *ri* :fold-pose-back arm)
+    (send *ri* :wait-interpolation)))
+
+
+(defun jsk_arc2017_baxter::pick-init (&key (ctype :default-controller) (moveit nil))
+  (let (mvit-env mvit-rb)
+    (when moveit
+      (setq mvit-env (instance jsk_2016_01_baxter_apc::baxter-moveit-environment))
+      (setq mvit-rb (instance jsk_arc2017_baxter::baxter-robot :init)))
+    (unless (boundp '*ri*)
+      (setq *ri* (instance jsk_arc2017_baxter::baxter-interface :init :type ctype
+                           :moveit-environment mvit-env
+                           :moveit-robot mvit-rb)))
+    (unless (boundp '*baxter*)
+      (setq *baxter* (instance jsk_arc2017_baxter::baxter-robot :init)))
+    (unless (boundp '*co*)
+      (setq *co* (when moveit (instance collision-object-publisher :init))))
+    (unless (boundp '*ti*)
+      (setq *ti* (instance jsk_arc2017_baxter::pick-interface :init)))
+    (send *baxter* :angle-vector (send *ri* :state :potentio-vector))
+    (send *ri* :calib-grasp :arms)))

--- a/jsk_arc2017_baxter/euslisp/pick-main.l
+++ b/jsk_arc2017_baxter/euslisp/pick-main.l
@@ -2,10 +2,119 @@
 
 (ros::roseus "robot_main")
 
-(require "package://jsk_arc2017_baxter/euslisp/lib/arc-interface.l")
+(require "package://jsk_arc2017_baxter/euslisp/lib/pick-interface.l")
+;; smach
+(require :state-machine "package://roseus_smach/src/state-machine.l")
+(require :state-machine-ros "package://roseus_smach/src/state-machine-ros.l")
+(require :state-machine-utils "package://roseus_smach/src/state-machine-utils.l")
+
+(defun make-picking-state-machine ()
+  (setq *sm*
+        (make-state-machine
+          '((:init -> :recognize-bin-boxes)
+            (:recognize-bin-boxes -> :wait-for-user-input)
+            (:wait-for-user-input -> :wait-for-opposite-arm)
+            (:wait-for-user-input !-> :wait-for-user-input)
+            (:wait-for-opposite-arm -> :set-target)
+            (:wait-for-opposite-arm !-> :wait-for-opposite-arm)
+            (:set-target -> :recognize-object)
+            (:set-target !-> :finish)
+            (:recognize-object -> :pick-object)
+            (:recognize-object !-> :return-from-recognize-object)
+            (:return-from-recognize-object -> :wait-for-opposite-arm-start-picking)
+            (:pick-object -> :verify-object)
+            (:pick-object !-> :return-from-pick-object)
+            (:return-from-pick-object -> :check-fail-count)
+            (:check-fail-count -> :wait-for-opposite-arm-start-picking)
+            (:check-fail-count !-> :wait-for-opposite-arm)
+            (:verify-object -> :set-target-cardboard)
+            (:verify-object !-> :return-object)
+            (:return-object -> :wait-for-opposite-arm)
+            (:set-target-cardboard -> :place-object)
+            (:set-target-cardboard !-> :return-object)
+            (:place-object -> :return-from-place-object)
+            (:return-from-place-object -> :wait-for-opposite-arm)
+            (:wait-for-opposite-arm-start-picking -> :wait-for-opposite-arm)
+            (:wait-for-opposite-arm-start-picking !-> :wait-for-opposite-arm-start-picking))
+          '((:init
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :init)
+                 (ros::ros-info "start ~a picking" (arm2str *arm*))
+                 t))
+            (:recognize-bin-boxes
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :recognize-bin-boxes)
+                 (send *ti* :recognize-bin-boxes)
+                 t))
+            (:wait-for-user-input
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :wait-for-user-input)
+                 (send *ti* :wait-for-user-input *arm*)))
+            (:wait-for-opposite-arm
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :wait-for-opposite-arm)
+                 (send *ti* :check-can-start *arm* :set-target
+                       :wait-for-opposite-arm)))
+            (:set-target
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :set-target)
+                 (send *ti* :set-target *arm*)))
+            (:recognize-object
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :recognize-object)
+                 (send *ti* :recognize-object *arm* :trial-times 10)))
+            (:return-from-recognize-object
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :return-from-recognize-object)
+                 (send *ti* :return-from-recognize-object *arm*)
+                 t))
+            (:pick-object
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :pick-object)
+                 (send *ti* :pick-object *arm*)))
+            (:return-from-pick-object
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :return-from-pick-object)
+                 (send *ti* :return-from-pick-object *arm*)
+                 t))
+            (:verify-object
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :verify-object)
+                 (send *ti* :verify-object *arm*)))
+            (:check-fail-count
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :check-fail-count)
+                 (send *ti* :check-fail-count *arm*)))
+            (:set-target-cardboard
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :set-target-cardboard)
+                 (send *ti* :set-target-cardboard *arm*)))
+            (:return-object
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :return-object)
+                 (send *ti* :return-object *arm*)
+                 t))
+            (:place-object
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :place-object)
+                 (send *ti* :place-object *arm*)
+                 t))
+            (:return-from-place-object
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :return-from-place-object)
+                 (send *ti* :return-from-place-object *arm*)
+                 t))
+            (:wait-for-opposite-arm-start-picking
+              '(lambda (userdata)
+                 (send *ti* :update-state *arm* :wait-for-opposite-arm-start-picking)
+                 (send *ti* :check-can-start *arm* :wait-for-opposite-arm
+                       :wait-for-opposite-arm-start-picking))))
+          '(:init)
+          '(:finish))))
+
 
 (defun pick-init (&key (ctype :default-controller) (calib-pressure t) (moveit nil))
-  (jsk_arc2017_baxter::arc-init :ctype ctype :moveit moveit)
+  (jsk_arc2017_baxter::pick-init :ctype ctype :moveit moveit)
   (when moveit (send *ti* :wipe-all-scene))
   (send *ri* :gripper-servo-on)
   (send *ri* :angle-vector (send *baxter* :fold-pose-back))
@@ -17,220 +126,11 @@
   t)
 
 (defun pick-mainloop (arm)
-  (ros::ros-info "[main] recognizing shelf bin boxes")
-  (send *ti* :recognize-bin-boxes :stamp (ros::time-now))
-  (ros::ros-info "[main] recognizing cardboard boxes")
-  (send *ti* :set-movable-region-for-bin :offset (list 80 120 0))
-
-  (setq label-names (ros::get-param (format nil "/~a_hand_camera/label_names" (arm2str arm))))
-  (setq bins (list :a :b :c))
-
-  (let (state order target-obj target-cardboard
-        fail-count dropped recognition-trial-time is-recognized)
-    (setq state :wait_for_user_input)
-    (send *ti* :set-arm-state-param arm state)
-    (setq fail-count 0)
-    (while t
-      (case state
-        (:wait_for_user_input
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          ;; wait user input to start the task
-          (send *ti* :wait-for-user-input-to-start arm)
-          (setq state :initialize)
-          (send *ti* :set-arm-state-param arm state))
-        (:initialize
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (setq label-names (ros::get-param (format nil "/~a_hand_camera/label_names" (arm2str arm))))
-          (setq state :set_target)
-          (send *ti* :set-arm-state-param arm state))
-        (:set_target
-          ;; next order
-          (setq order (send *ti* :get-next-work-order arm order))
-          (if (null order)
-            (progn
-              ;; all work orders are done so go to 'wait' status
-              (setq state :wait_for_user_input))
-            (progn
-              (ros::ros-warn "next-work-order: ~a" (send order :item))
-              ;; get target param
-              (setq target-bin (str2symbol (send order :bin)))
-              (setq target-obj (send order :item))
-              (setq target-cardboard (str2symbol (send order :box)))
-              (setq bin-contents (send *ti* :get-bin-contents target-bin))
-              (ros::set-param
-                (format nil "~a_hand/target_object" (arm2str arm)) target-obj)
-              (ros::set-dynparam
-                (format nil "/~a_hand_camera/bbox_array_to_bbox" (arm2str arm))
-                (cons "index" (position target-bin bins)))
-              (ros::set-dynparam
-                (format nil "/~a_hand_camera/label_to_mask" (arm2str arm))
-                (cons "label_value" (position target-obj label-names :test #'string=)))
-              (send *ti* :set-object-segmentation-candidates arm
-                (mapcar #'(lambda (x) (position x label-names :test #'string=))
-                        (append (list "__background__") bin-contents (list "__shelf__"))))
-              (if (send *ti* :check-bin-exist target-bin)
-                (progn
-                  (ros::set-param
-                    (format nil "~a_hand/target_bin" (arm2str arm))
-                    (symbol2str target-bin))
-                  ;; logging
-                  (ros::ros-info-blue "[~a] [main] state: ~a, target-bin: ~a, target-obj: ~a" (ros::get-name) state target-bin target-obj)
-                  (setq state :wait_for_opposite_arm))
-                (progn
-                  (ros::ros-warn "[~a] [main] could not find bin box: ~a" (ros::get-name) target-bin)
-                  (setq state :set_target)))))
-          (send *ti* :set-arm-state-param arm state))
-        (:wait_for_opposite_arm
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (ros::ros-info "[main] Need to wait for opposite arm: ~a" arm)
-          (while
-            (send *ti* :need-to-wait-opposite-arm arm state)
-            (unix::sleep 1))
-          (setq state :recognize_objects_in_bin)
-          (send *ti* :set-arm-state-param arm state))
-        (:recognize_objects_in_bin
-          (send *ti* :add-shelf-scene)
-          (send *ti* :add-cardboard-scene arm)
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (send *baxter* :head_pan :joint-angle (if (eq arm :larm) -80 80))
-          (ros::ros-info "[main] Recognizing objects in bin ~a" target-bin)
-          (send *ti* :move-arm-body->bin-overlook-pose arm target-bin)
-          (send *ri* :wait-interpolation)
-          (setq recognition-trial-time 1)
-          (setq is-recognized nil)
-          (while (null (or (> recognition-trial-time 10) is-recognized))
-            (setq is-recognized
-                  (send *ti* :recognize-objects-in-bin arm :stamp (ros::time-now)))
-            (setq recognition-trial-time (incf recognition-trial-time)))
-          (if is-recognized
-            (setq state :pick_object)
-            (progn
-              (ros::ros-info "[main] arm: ~a, failed to recognize object ~a" arm target-obj)
-              (send *ri* :angle-vector-sequence
-                    (list (send *baxter* :fold-to-keep-object arm)
-                          (send *baxter* :fold-pose-back arm))
-                    :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
-              (send *ri* :wait-interpolation)
-              (send *ti* :delete-shelf-scene)
-              (send *ti* :delete-cardboard-scene arm)
-              (setq state :wait_for_opposite_arm_start_picking)))
-          (send *ti* :set-arm-state-param arm state))
-        (:pick_object
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (send *ti* :delete-shelf-scene)
-          (send *ti* :pick-object-in-bin arm target-bin
-                :n-trial 2
-                :n-trial-same-pos 1
-                :do-stop-grasp nil)
-          (send *ri* :angle-vector
-                (send *ti* :ik->bin-center arm target-bin
-                      :offset #f(0 0 300) :rotation-axis :z :use-gripper t)
-                3000 (send *ri* :get-arm-controller arm) 0)
-          (send *ri* :wait-interpolation)
-          (setq graspingp (send *ri* :graspingp arm))
-          (setq state :verify_object)
-          (send *ti* :set-arm-state-param arm state))
-        (:verify_object
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (ros::ros-info "[main] arm: ~a graspingp: ~a" arm graspingp)
-          (if graspingp
-            (progn
-              (setq fail-count 0)
-              ;; TODO: in-hand verification
-              ;; TODO:   target-obj = in-hand object  -> :set_target_cardboard
-              ;; TODO:   target-obj != in-hand object -> :return_object
-              (if target-obj
-                  (setq state :set_target_cardboard)
-                  (setq state :return_object)))
-            (progn
-              (setq fail-count (incf fail-count))
-              (send *ri* :stop-grasp arm)
-              (ros::ros-info "[main] arm: ~a, picking fail count: ~a" arm fail-count)
-              (send *ri* :angle-vector-sequence
-                    (list (send *baxter* :avoid-shelf-pose arm (if (eq arm :larm) :d :f))
-                          (send *baxter* :fold-pose-back arm))
-                    :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
-              (send *ri* :wait-interpolation)
-              (if (> fail-count 1)
-                (setq state :wait_for_opposite_arm_start_picking)
-                (setq state :wait_for_opposite_arm))))
-          (send *ti* :set-arm-state-param arm state))
-        (:wait_for_opposite_arm_start_picking
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (ros::ros-info "[main] Waiting for opposite arm start picking: ~a" arm)
-          (while
-            (send *ti* :need-to-wait-opposite-arm arm state)
-            (unix::sleep 1))
-          (setq state :wait_for_opposite_arm)
-          (send *ti* :set-arm-state-param arm state))
-        (:set_target_cardboard
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (setq dropped nil)
-          (if (eq target-cardboard :shelf)
-            (progn
-              (ros::ros-info "[main] blacklisted object, return to shelf")
-              (setq state :return_object))
-            (progn
-              (ros::set-param (format nil "~a_hand/target_box" (arm2str arm)) (symbol2str target-cardboard))
-              ;; logging
-              (ros::ros-info "[main] target-cardboard: ~a" target-cardboard)
-              (setq state :place_object)))
-          (send *ti* :set-arm-state-param arm state))
-        (:return_object
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (send *ri* :angle-vector
-                (send *ti* :ik->bin-center arm target-bin
-                      :offset #f(0 0 0) :coords-pitch 0
-                      :rotation-axis :z
-                      :use-gripper t)
-                :fast (send *ri* :get-arm-controller arm) 0 :scale 3.0)
-          (send *ri* :wait-interpolation)
-          (send *ri* :stop-grasp arm)
-          (send *ti* :spin-off-by-wrist arm :times 5)
-          (send *ri* :wait-interpolation)
-          (ros::ros-info "[main] ~a, return object in shelf" arm)
-          (send *ti* :add-shelf-scene)
-          (send *ri* :fold-pose-back arm)
-          (send *ri* :wait-interpolation)
-          (setq state :set_target)
-          (send *ti* :set-arm-state-param arm state))
-        (:place_object
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (ros::ros-info "[main] ~a, place object in bin ~a" arm target-cardboard)
-          (send *ti* :add-shelf-scene)
-          (send *baxter* :head_pan :joint-angle (if (eq arm :larm) 80 -80))
-          (send *ri* :angle-vector
-                (send *ti* :ik->cardboard-entrance arm target-cardboard
-                      :offset #f(0 0 300) :rotation-axis :z :use-gripper t)
-                4000 (send *ri* :get-arm-controller arm) 0)
-          (send *ri* :wait-interpolation)
-          (setq dropped (not (send *ri* :graspingp arm)))
-          (if dropped
-            (progn
-              (ros::ros-error "[main] arm ~a: dropped object" arm)
-              (send *ri* :stop-grasp arm))
-            (progn
-              (ros::ros-info-green "[main] arm ~a: place object ~a in cardboard ~a" arm target-obj target-cardboard)
-              (send *ti* :delete-cardboard-scene arm)
-              (send *ri* :angle-vector-raw (send *baxter* arm :move-end-pos #f(0 0 -300) :world)
-                    2000 (send *ri* :get-arm-controller arm) 0)
-              (send *ri* :wait-interpolation)
-              (send *ri* :stop-grasp arm) ;; release object
-              (send *ti* :spin-off-by-wrist arm :times 10)
-              (send *ri* :wait-interpolation)
-              (send *ri* :angle-vector-raw (send *baxter* arm :move-end-pos #f(0 0 300) :world)
-                    1000 (send *ri* :get-arm-controller arm) 0)
-              (send *ri* :wait-interpolation)
-              (send *ti* :add-cardboard-scene arm)))
-          (setq state :return_from_cardboard)
-          (send *ti* :set-arm-state-param arm state))
-        (:return_from_cardboard
-          (ros::ros-info "[main] ~a, ~a" arm state)
-          (send *ri* :fold-pose-back arm)
-          (send *ri* :wait-interpolation)
-          (setq state :set_target)
-          (send *ti* :set-arm-state-param arm state))))))
+  (setq *arm* arm)
+  (when (not (boundp '*sm*))
+    (make-picking-state-machine))
+  (exec-state-machine *sm* nil :root-name (format nil "SM_~a_ROOT" (string-upcase (arm2str arm)))))
 
 (warn "~% Commands ~%")
-(warn "(pick-init)     : initialize *ti*~%")
-(warn "(pick-mainloop) : start the mainloop~%~%")
+(warn "(pick-init)           : initialize *ti*~%")
+(warn "(pick-mainloop :rarm) : start the mainloop~%~%")

--- a/jsk_arc2017_baxter/launch/main/pick.launch
+++ b/jsk_arc2017_baxter/launch/main/pick.launch
@@ -24,6 +24,10 @@
   <!-- state_server -->
   <node pkg="jsk_arc2017_baxter" type="state_server.py" name="state_server" />
 
+  <!-- smach viewer -->
+  <!-- FIXME: Segmentation Fault occurs on sheeta -->
+  <!-- <node pkg="smach_viewer" type="smach_viewer.py" name="smach_viewer" /> -->
+
   <!-- parameter -->
   <param name="/left_hand/target_bin" value="" />
   <param name="/right_hand/target_bin" value="" />

--- a/jsk_arc2017_baxter/launch/main/pick.launch
+++ b/jsk_arc2017_baxter/launch/main/pick.launch
@@ -21,10 +21,11 @@
     </rosparam>
   </node>
 
+  <!-- state_server -->
+  <node pkg="jsk_arc2017_baxter" type="state_server.py" name="state_server" />
+
   <!-- parameter -->
-  <param name="/left_hand/state" value="" />
   <param name="/left_hand/target_bin" value="" />
-  <param name="/right_hand/state" value="" />
   <param name="/right_hand/target_bin" value="" />
 
   <node name="rqt_yn_btn"

--- a/jsk_arc2017_baxter/node_scripts/state_server.py
+++ b/jsk_arc2017_baxter/node_scripts/state_server.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*- from jsk_arc2017_baxter.srv import CheckCanStart
+
+from jsk_arc2017_baxter.srv import CheckCanStart
+from jsk_arc2017_baxter.srv import CheckCanStartResponse
+from jsk_arc2017_baxter.srv import GetState
+from jsk_arc2017_baxter.srv import GetStateResponse
+from jsk_arc2017_baxter.srv import UpdateState
+from jsk_arc2017_baxter.srv import UpdateStateResponse
+import rospy
+import threading
+
+
+class StateServer(object):
+    def __init__(self):
+        super(StateServer, self).__init__()
+        self.state = {
+            'right': 'init',
+            'left': 'init'
+        }
+        self.lock = threading.Lock()
+        self.thread = threading.Thread(target=self._run_services)
+
+    def run(self):
+        self.thread.start()
+
+    def _run_services(self):
+        self.services = []
+        self.services.append(
+            rospy.Service(
+                '~left_hand/update_state',
+                UpdateState,
+                self._update_left_state))
+        self.services.append(
+            rospy.Service(
+                '~right_hand/update_state',
+                UpdateState,
+                self._update_right_state))
+        self.services.append(
+            rospy.Service(
+                '~left_hand/get_state',
+                GetState,
+                self._get_left_state))
+        self.services.append(
+            rospy.Service(
+                '~right_hand/get_state',
+                GetState,
+                self._get_right_state))
+        self.services.append(
+            rospy.Service(
+                '~left_hand/check_can_start',
+                CheckCanStart,
+                self._check_left_can_start))
+        self.services.append(
+            rospy.Service(
+                '~right_hand/check_can_start',
+                CheckCanStart,
+                self._check_right_can_start))
+        rospy.spin()
+
+    def _check_left_can_start(self, req):
+        can_start = self._check_can_start(
+            'left', req.start_state, req.wait_state)
+        return CheckCanStartResponse(can_start=can_start)
+
+    def _check_right_can_start(self, req):
+        can_start = self._check_can_start(
+            'right', req.start_state, req.wait_state)
+        return CheckCanStartResponse(can_start=can_start)
+
+    def _check_can_start(self, hand, start_state, wait_state):
+        self.lock.acquire()
+        if hand == 'left':
+            opposite_hand = 'right'
+        else:
+            opposite_hand = 'left'
+        state = self.state[hand]
+        opposite_state = self.state[opposite_hand]
+
+        # wait condition
+        if state == 'wait-for-opposite-arm-start-picking':
+            if opposite_state == 'recognize-object' \
+                    or opposite_state == 'wait-for-user-input':
+                can_start = True
+            else:
+                can_start = False
+        elif state == 'wait-for-opposite-arm':
+            if opposite_state == 'set-target' \
+                    or opposite_state == 'recognize-object' \
+                    or opposite_state == 'pick-object' \
+                    or opposite_state == 'verify-object' \
+                    or opposite_state == 'set-target-cardboard' \
+                    or opposite_state == 'return-object':
+                can_start = False
+            else:
+                can_start = True
+        else:
+            can_start = True
+
+        if can_start:
+            self.state[hand] = start_state
+        else:
+            self.state[hand] = wait_state
+        self.lock.release()
+        return can_start
+
+    def _update_left_state(self, req):
+        is_updated = self._update_state(req.state, 'left')
+        return UpdateStateResponse(updated=is_updated)
+
+    def _update_right_state(self, req):
+        is_updated = self._update_state(req.state, 'right')
+        return UpdateStateResponse(updated=is_updated)
+
+    def _update_state(self, state, hand):
+        self.lock.acquire()
+        is_updated = True
+        try:
+            self.state[hand] = state
+        except Exception:
+            is_updated = False
+        self.lock.release()
+        return is_updated
+
+    def _get_left_state(self, req):
+        self.lock.acquire()
+        state = self.state['left']
+        self.lock.release()
+        return GetStateResponse(state=state)
+
+    def _get_right_state(self, req):
+        self.lock.acquire()
+        state = self.state['right']
+        self.lock.release()
+        return GetStateResponse(state=state)
+
+
+if __name__ == "__main__":
+    rospy.init_node('state_server')
+    state_server = StateServer()
+    state_server.run()

--- a/jsk_arc2017_baxter/package.xml
+++ b/jsk_arc2017_baxter/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>jsk_apc2016_common</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>roseus</build_depend>
 
   <run_depend>jsk_2015_05_baxter_apc</run_depend>
@@ -30,6 +31,7 @@
   <run_depend>jsk_rqt_plugins</run_depend>
   <run_depend>jsk_rviz_plugins</run_depend>
   <run_depend>jsk_topic_tools</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>xacro</run_depend>

--- a/jsk_arc2017_baxter/srv/CheckCanStart.srv
+++ b/jsk_arc2017_baxter/srv/CheckCanStart.srv
@@ -1,0 +1,4 @@
+string start_state
+string wait_state
+---
+bool can_start

--- a/jsk_arc2017_baxter/srv/GetState.srv
+++ b/jsk_arc2017_baxter/srv/GetState.srv
@@ -1,0 +1,2 @@
+---
+string state

--- a/jsk_arc2017_baxter/srv/UpdateState.srv
+++ b/jsk_arc2017_baxter/srv/UpdateState.srv
@@ -1,0 +1,4 @@
+string state
+---
+bool updated
+bool can_start


### PR DESCRIPTION
Close #2104 and #2110 
Requires https://github.com/jsk-ros-pkg/jsk_roseus/pull/520

## Main Changes
- current `pick-main.l` moves to `lib/pick-interface.l`
  - `pick-interface` inherits `arc-interface`
- add `state_server.py` for dual-arm picking
  - add `UpdateState, GetState, CheckCanStart` srv
  - `euslisp` processes set their current state with srv `UpdateState`
  - `euslisp` processes check `can-start` with srv `CheckCanStart`
  - `GetState` is command line, i.e. `$ rosservice call /state_server/right_hand/get_state` returns `state`.
- Use smach state machine in `pick-main.l`

## State Machine

![arc_state_machine](https://cloud.githubusercontent.com/assets/9300063/26728117/156a7456-47e4-11e7-96c9-4225fd8ef9c4.png)


