### PR TITLE
fix typo in baxter.launch

### DIFF
--- a/jsk_arc2017_baxter/launch/setup/baxter.launch
+++ b/jsk_arc2017_baxter/launch/setup/baxter.launch
@@ -65,7 +65,7 @@
   </group>
 
   <!-- picking source location: shelf/tote -->
-  <include file="$(find jsk_arc2017_baxter)/launch/setup/incude/setup_source_location.xml">
+  <include file="$(find jsk_arc2017_baxter)/launch/setup/include/setup_source_location.xml">
     <arg name="pick" value="$(arg pick)" />
   </include>
 


### PR DESCRIPTION
fix typo

`incude`
->
`include`