### PR TITLE
remove released jsk_roseus from fc.rosinstall

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -7,10 +7,6 @@
     uri: https://github.com/jsk-ros-pkg/jsk_recognition.git
     version: master
 - git:
-    local-name: jsk-ros-pkg/jsk_roseus
-    uri: https://github.com/jsk-ros-pkg/jsk_roseus.git
-    version: master
-- git:
     local-name: FOR_ASTRA/openni2_camera
     uri: https://github.com/ros-drivers/openni2_camera.git
     version: indigo-devel


### PR DESCRIPTION
newest `jsk_roseus` is released in https://github.com/ros/rosdistro/pull/15322