### PR TITLE
Modify joint_limits and use raw angle-vector methods in some part

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
@@ -259,7 +259,7 @@
       (send *ri* :gripper-servo-on arm)
       (if (eq arm :larm)
         (progn
-          (send *ri* :angle-vector
+          (send *ri* :angle-vector-raw
                 (send *baxter* arm :inverse-kinematics
                       (make-coords :pos (v+ obj-pos #f(0 0 150))
                                    :rpy #f(0 0 0))
@@ -284,7 +284,7 @@
           (setq gripper-x (send *baxter* arm :gripper-x :joint-angle))
           (send *baxter* :angle-vector prev-av)
           ;; First, move prismatic joint to target position
-          (send *ri* :angle-vector
+          (send *ri* :angle-vector-raw
                 (send *baxter* :slide-gripper arm gripper-x :relative nil)
                 :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
           (send *ri* :wait-interpolation)
@@ -294,7 +294,7 @@
           (send *ri* :move-hand arm
                 (send *baxter* :hand-grasp-pose arm :cylindrical :angle 100) 1000)
           ;; Move whole arm to target pose
-          (send *ri* :angle-vector
+          (send *ri* :angle-vector-raw
                 (send *baxter* :angle-vector next-av)
                 :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
           (send *ri* :wait-interpolation)))
@@ -310,7 +310,7 @@
                         :offset (float-vector 0 0 (- (* i -50) 30))))
             (pushback (send *baxter* :angle-vector) avs))))
       (when do-stop-grasp (unless graspingp (send *ri* :stop-grasp arm)))
-      (send *ri* :angle-vector-sequence (reverse avs)
+      (send *ri* :angle-vector-sequence-raw (reverse avs)
             :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
       (send *ri* :wait-interpolation)
       (when (eq arm :rarm)
@@ -468,7 +468,7 @@
         (send self :ik->bin-center arm bin
               :offset offset :rpy rpy :use-gripper nil)
         avs)
-      (send *ri* :angle-vector-sequence avs :fast
+      (send *ri* :angle-vector-sequence-raw avs :fast
             (send *ri* :get-arm-controller arm) 0 :scale 3.0)))
   (:move-arm-body->tote-overlook-pose
     (arm &key (gripper-angle 90))
@@ -483,7 +483,7 @@
         (send self :ik->tote-center arm
               :offset offset :rpy rpy :use-gripper nil)
         avs)
-      (send *ri* :angle-vector-sequence avs :fast
+      (send *ri* :angle-vector-sequence-raw avs :fast
             (send *ri* :get-arm-controller arm) 0 :scale 3.0)))
   (:wait-for-user-input-to-start (arm)
     (let (can-start)

--- a/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
@@ -95,7 +95,7 @@
       is-recognized))
   (:return-from-recognize-object (arm)
     (ros::ros-info "[main] arm: ~a, failed to recognize object ~a" arm target-obj)
-    (send *ri* :angle-vector-sequence
+    (send *ri* :angle-vector-sequence-raw
           (list (send *baxter* :fold-to-keep-object arm)
                 (send *baxter* :fold-pose-back arm))
           :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
@@ -118,7 +118,7 @@
     graspingp)
   (:return-from-pick-object (arm)
     (send *ri* :stop-grasp arm)
-    (send *ri* :angle-vector-sequence
+    (send *ri* :angle-vector-sequence-raw
           (list (send *baxter* :avoid-shelf-pose arm (if (eq arm :larm) :d :f))
                 (send *baxter* :fold-pose-back arm))
           :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
@@ -144,7 +144,7 @@
         (ros::ros-info "[main] target-cardboard: ~a" target-cardboard)
         t)))
   (:return-object (arm)
-    (send *ri* :angle-vector
+    (send *ri* :angle-vector-raw
           (send self :ik->bin-center arm target-bin
                 :offset #f(0 0 0) :rotation-axis :z :use-gripper t)
           :fast (send *ri* :get-arm-controller arm) 0 :scale 3.0)

--- a/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
@@ -77,7 +77,7 @@
       is-recognized))
   (:return-from-recognize-object (arm)
     (ros::ros-info "[main] arm: ~a, failed to recognize object in tote" arm)
-    (send *ri* :angle-vector-sequence
+    (send *ri* :angle-vector-sequence-raw
           (list (send *baxter* :fold-to-keep-object arm)
                 (send *baxter* :fold-pose-back arm))
           :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
@@ -106,7 +106,7 @@
   (:return-from-pick-object (arm)
     (send *ri* :stop-grasp arm)
     (ros::ros-info "[main] arm: ~a return from pick-object to fold-pose-back" arm)
-    (send *ri* :angle-vector-sequence
+    (send *ri* :angle-vector-sequence-raw
           (list (send *baxter* :avoid-shelf-pose arm (if (eq arm :larm) :d :f))
                 (send *baxter* :fold-pose-back arm))
           :fast (send *ri* :get-arm-controller arm) 0 :scale 5.0)
@@ -135,7 +135,7 @@
         (ros::ros-info "[main] target-bin: ~a" target-bin)
         t)))
   (:return-object (arm)
-    (send *ri* :angle-vector
+    (send *ri* :angle-vector-raw
           (send self :ik->tote-center arm :offset #f(0 0 0)
                 :rotation-axis :z :use-gripper t)
           :fast (send *ri* :get-arm-controller arm) 0 :scale 3.0)

--- a/jsk_arc2017_baxter/launch/setup/include/planning_context.launch
+++ b/jsk_arc2017_baxter/launch/setup/include/planning_context.launch
@@ -14,7 +14,6 @@
 
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
-    <rosparam command="load" file="$(find baxter_moveit_config)/config/joint_limits.yaml"/>
     <rosparam command="load" file="$(find jsk_arc2017_baxter)/robots/moveit_config/joint_limits.yaml"/>
   </group>
 

--- a/jsk_arc2017_baxter/robots/moveit_config/joint_limits.yaml
+++ b/jsk_arc2017_baxter/robots/moveit_config/joint_limits.yaml
@@ -2,11 +2,80 @@
 # Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
 # Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
+  left_e0:
+    has_velocity_limits: true
+    max_velocity: 1.5
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_e1:
+    has_velocity_limits: true
+    max_velocity: 1.5
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_s0:
+    has_velocity_limits: true
+    max_velocity: 1.5
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_s1:
+    has_velocity_limits: true
+    max_velocity: 1.5
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_w0:
+    has_velocity_limits: true
+    max_velocity: 4.0
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_w1:
+    has_velocity_limits: true
+    max_velocity: 4.0
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_w2:
+    has_velocity_limits: true
+    max_velocity: 4.0
+    has_acceleration_limits: true
+    max_acceleration: 2.0
   left_gripper_vacuum_pad_joint:
     has_velocity_limits: true
     max_velocity: 4.5
     has_acceleration_limits: false
     max_acceleration: 0
+  right_e0:
+    has_velocity_limits: true
+    max_velocity: 1.5
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_e1:
+    has_velocity_limits: true
+    max_velocity: 1.5
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_s0:
+    has_velocity_limits: true
+    max_velocity: 1.5
+    has_acceleration_limits: true
+  right_s1:
+    has_velocity_limits: true
+    max_velocity: 1.5
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_w0:
+    has_velocity_limits: true
+    max_velocity: 4.0
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_w1:
+    has_velocity_limits: true
+    max_velocity: 4.0
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_w2:
+    has_velocity_limits: true
+    max_velocity: 4.0
+    has_acceleration_limits: true
+    max_acceleration: 2.0
   right_gripper_prismatic_joint:
     has_velocity_limits: true
     max_velocity: 0.132


### PR DESCRIPTION
- update `joint_limits.yaml` (these values are same as URDF)
- use `angle-vector-sequecne-raw` and `angle-vector-raw`
   - current programs are designed to use raw methods with `:fast`
   -  but `pr2eus_moveit` supports `:fast` with https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/282, 