### PR TITLE
[doc] update docs for stow task and new nodes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,7 +32,7 @@ source_suffix = ['.rst', '.md']
 
 master_doc = 'index'
 project = u'jsk_apc'
-copyright = u'2015, JSK Lab'
+copyright = u'2017, JSK Lab'
 author = u'Kentaro Wada'
 language = 'en'
 

--- a/doc/jsk_arc2017_baxter/arc2017_stow_trial.rst
+++ b/doc/jsk_arc2017_baxter/arc2017_stow_trial.rst
@@ -1,0 +1,19 @@
+ARC2017 Stow Task Trial on Real World
+=====================================
+
+Stow task trial on real world for ARC2017 can be done on ``baxter@sheeta``.
+
+- Prepare json.
+- Set objects in Tote.
+
+.. code-block:: bash
+
+  # Launch nodes to control robot.
+  baxter@sheeta $ roslaunch jsk_arc2017_baxter baxter.launch pick:=false
+
+  # Launch nodes in recognition pipeline for stow task.
+  baxter@sheeta $ roslaunch jsk_arc2017_baxter setup_for_stow.launch
+
+  # Run task!
+  baxter@sheeta $ roslaunch jsk_arc2017_baxter stow.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_stow_task
+

--- a/doc/jsk_arc2017_baxter/index.rst
+++ b/doc/jsk_arc2017_baxter/index.rst
@@ -9,6 +9,7 @@ jsk_arc2017_baxter
    :glob:
 
    arc2017_pick_trial
+   arc2017_stow_trial
    usage_of_baxter
    setup_gripper_v6
 

--- a/doc/jsk_arc2017_common/nodes/json_saver.md
+++ b/doc/jsk_arc2017_common/nodes/json_saver.md
@@ -1,0 +1,42 @@
+# json\_saver.py
+
+
+## What is this?
+
+Update and save item location JSON file during the tasks.
+
+## Services
+
+- `~update_json` (`jsk_arc2017_common/UpdateJSON`)
+
+  Update and save `item_location_file.json`
+
+```bash
+$ rossrv show jsk_arc2017_common/UpdateJSON
+string item
+string src
+string dst
+---
+bool updated
+```
+
+- `~save_json` (`std_srvs/Trigger`)
+
+  Save `item_location_file.json`.
+
+## Parameters
+
+- `~json_dir` (String, required)
+
+  Directory where initial json files are located
+
+- `~output_dir` (String, required)
+
+  Directory where output json files will be located
+
+
+## Sample
+
+```bash
+roslaunch jsk_arc2017_common sample_json_saver.launch
+```

--- a/doc/jsk_arc2017_common/nodes/work_order_publisher.md
+++ b/doc/jsk_arc2017_common/nodes/work_order_publisher.md
@@ -1,0 +1,37 @@
+# work\_order\_publisher.py
+
+## What is this?
+
+Publish optimized work orders of the tasks.
+
+
+## Subscribing topics
+
+None
+
+## Publishing topics
+
+- `~left_hand` (`jsk_arc2017_common/WorkOrderArray`)
+
+  Optimized work orders for left hand.
+
+- `~right_hand` (`jsk_arc2017_common/WorkOrderArray`)
+
+  Optimized work orders for right hand.
+
+
+## Parameters
+
+- `~json_dir` (String, required)
+
+  Directory where initial json files are located
+
+- `~rate` (Int, default: `1`)
+
+  Hz of publishing topics
+
+## Sample
+
+```bash
+roslaunch jsk_arc2017_common sample_work_order_publisher.launch
+```


### PR DESCRIPTION
Close #2193 and #2194 
- add json_saver and work_order_publisher doc
- add jsk_arc2017_baxter stow task doc 
- update copyright year to 2017