### PR TITLE
return nil when largest bbox subscription timeout

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
@@ -223,13 +223,15 @@
                                         :timeout 10000
                                         :after-stamp stamp))
       (dolist (box (send box-msg :boxes))
-        (let (volume)
-          (setq volume (* (send box :dimensions :x)
-                          (send box :dimensions :y)
-                          (send box :dimensions :z)))
-          (if (> bbox-volume-threshold- volume)
-            (return-from :get-largest-object-index
-                         (+ (send box :label) 1)))))))
+        (when box
+          (let (volume)
+            (setq volume (* (send box :dimensions :x)
+                            (send box :dimensions :y)
+                            (send box :dimensions :z)))
+            (if (> bbox-volume-threshold- volume)
+              (return-from :get-largest-object-index
+                           (+ (send box :label) 1))))))
+      nil))
   (:pick-object-in-bin
     (arm bin &rest args)
     (let (graspingp movable-region)

--- a/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
@@ -64,15 +64,16 @@
       (setq recognition-count 1)
       (while (null (or (> recognition-count trial-times) is-recognized))
         (setq target-index (send self :get-largest-object-index arm :stamp (ros::time-now)))
-        (setq target-obj (elt label-names target-index))
-        (ros::set-dynparam
-          (format nil "/~a_hand_camera/label_to_mask" (arm2str arm))
-          (cons "label_value" target-index))
-        (ros::set-param
-          (format nil "~a_hand/target_object" (arm2str arm)) target-obj)
-        (ros::ros-info-blue "[~a] [main] :recognize-object, target-obj: ~a" (ros::get-name) target-obj)
         (setq is-recognized
-              (send self :recognize-target-object arm :stamp (ros::time-now)))
+          (when target-index
+            (setq target-obj (elt label-names target-index))
+            (ros::set-dynparam
+              (format nil "/~a_hand_camera/label_to_mask" (arm2str arm))
+              (cons "label_value" target-index))
+            (ros::set-param
+              (format nil "~a_hand/target_object" (arm2str arm)) target-obj)
+            (ros::ros-info-blue "[~a] [main] :recognize-object, target-obj: ~a" (ros::get-name) target-obj)
+            (send self :recognize-target-object arm :stamp (ros::time-now))))
         (setq recognition-count (incf recognition-count)))
       is-recognized))
   (:return-from-recognize-object (arm)


### PR DESCRIPTION
when `:get-largest-object-index` fails, this PR prevent error and return `nil` from the method