### PR TITLE
Update candidates for segmentation via topic in order to change candidates dynamically

### DIFF
--- a/doc/jsk_arc2017_common/nodes/candidates_publisher.md
+++ b/doc/jsk_arc2017_common/nodes/candidates_publisher.md
@@ -1,0 +1,40 @@
+# candidates\_publisher.py
+
+
+## What is this?
+
+Publish label candidates from JSON file.
+
+
+## Subscribing topics
+
+
+- `~input/json_dir` (`std_msgs/String`)
+
+  JSON file directory
+
+## Publishing topics
+
+- `~output/candidates` (`jsk_recognition_msgs/LabelArray`)
+
+  Label candidates in target location
+
+
+## Parameters
+
+- `~target_location` (String, required)
+
+   Target location name.
+   (`tote`, `bin_A`, `bin_B` or `bin_C`)
+
+   You can update by `dynamic_reconfigure`.
+
+- `~label_names` (List of String, required)
+
+  List of label names
+  
+## Sample
+
+```bash
+roslaunch jsk_arc2017_common sample_candidates_publisher.launch
+```

--- a/jsk_apc2016_common/launch/object_segmentation_3d.launch
+++ b/jsk_apc2016_common/launch/object_segmentation_3d.launch
@@ -28,6 +28,10 @@
   <node name="apply_context_to_label_proba"
         pkg="jsk_perception" type="apply_context_to_label_probability">
     <remap from="~input" to="fcn_object_segmentation/output/proba_image" />
+    <remap from="~input/candidates" to="candidates_publisher/output/candidates" />
+    <rosparam>
+      use_topic: true
+    </rosparam>
   </node>
 
   <!-- label -> cluster indices -->

--- a/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
@@ -503,6 +503,13 @@
         (format nil "/~a_hand_camera/apply_context_to_label_proba/update_candidates"
                 (arm2str arm))
         req)))
+  (:set-target-location (arm location)
+    (if (consp location)
+      (setq location (format nil "~a_~a" (symbol2str (car location)) (symbol-string (cdr location))))
+      (setq location (symbol2str location)))
+    (ros::set-dynparam
+      (format nil "/~a_hand_camera/candidates_publisher" (arm2str arm))
+      (cons "target_location" location)))
   (:set-arm-state-param (arm state)
     (ros::set-param (format nil "~a_hand/state" (arm2str arm)) (symbol2str state)))
   (:get-bin-contents (bin)

--- a/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
@@ -68,9 +68,7 @@
     (ros::set-dynparam
       (format nil "/~a_hand_camera/label_to_mask" (arm2str arm))
       (cons "label_value" (position target-obj label-names :test #'string=)))
-    (send self :set-object-segmentation-candidates arm
-      (mapcar #'(lambda (x) (position x label-names :test #'string=))
-              (append (list "__background__") bin-contents (list "__shelf__"))))
+    (send self :set-target-location arm (cons :bin target-bin))
     (ros::set-param
       (format nil "~a_hand/target_bin" (arm2str arm))
       (symbol2str target-bin))

--- a/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
@@ -49,9 +49,7 @@
             (ros::get-param (format nil "/~a_hand_camera/label_names"
                                     (arm2str arm))))
       (setq tote-contents (ros::get-param "/tote_contents"))
-      (send self :set-object-segmentation-candidates arm
-        (mapcar #'(lambda (x) (position x label-names :test #'string=))
-                (append (list "__background__") tote-contents (list "__shelf__"))))
+      (send self :set-target-location arm :tote)
       (when moveit-p (send self :add-shelf-scene))
       (when moveit-p (send self :add-tote-scene arm))
       (send *baxter* :head_pan :joint-angle (if (eq arm :larm) -80 80))

--- a/jsk_arc2017_baxter/launch/main/pick.launch
+++ b/jsk_arc2017_baxter/launch/main/pick.launch
@@ -49,6 +49,22 @@
         pkg="jsk_baxter_startup" type="xdisplay_image_topic.py"
         args="/visualize_json/output/item_location_viz" />
 
+  <!-- candidates publisher -->
+  <group ns="left_hand_camera">
+    <node name="candidates_publisher"
+        pkg="jsk_arc2017_common" type="candidates_publisher.py" >
+      <remap from="~input/json_dir" to="/json_saver/output/json_dir" />
+      <remap from="~label_names" to="label_names" />
+    </node>
+  </group>
+  <group ns="right_hand_camera">
+    <node name="candidates_publisher"
+        pkg="jsk_arc2017_common" type="candidates_publisher.py" >
+      <remap from="~input/json_dir" to="/json_saver/output/json_dir" />
+      <remap from="~label_names" to="label_names" />
+    </node>
+  </group>
+
   <!-- smach viewer -->
   <!-- FIXME: Segmentation Fault occurs on sheeta -->
   <!-- <node pkg="smach_viewer" type="smach_viewer.py" name="smach_viewer" /> -->

--- a/jsk_arc2017_baxter/launch/main/stow.launch
+++ b/jsk_arc2017_baxter/launch/main/stow.launch
@@ -42,6 +42,22 @@
         pkg="jsk_baxter_startup" type="xdisplay_image_topic.py"
         args="/visualize_json/output/item_location_viz" />
 
+  <!-- candidates publisher -->
+  <group ns="left_hand_camera">
+    <node name="candidates_publisher"
+        pkg="jsk_arc2017_common" type="candidates_publisher.py" >
+      <remap from="~input/json_dir" to="/json_saver/output/json_dir" />
+      <remap from="~label_names" to="label_names" />
+    </node>
+  </group>
+  <group ns="right_hand_camera">
+    <node name="candidates_publisher"
+        pkg="jsk_arc2017_common" type="candidates_publisher.py" >
+      <remap from="~input/json_dir" to="/json_saver/output/json_dir" />
+      <remap from="~label_names" to="label_names" />
+    </node>
+  </group>
+
   <!-- smach viewer -->
   <!-- FIXME: Segmentation Fault occurs on sheeta -->
   <!-- <node pkg="smach_viewer" type="smach_viewer.py" name="smach_viewer" /> -->

--- a/jsk_arc2017_common/CMakeLists.txt
+++ b/jsk_arc2017_common/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(jsk_arc2017_common)
 
 find_package(catkin REQUIRED
+    dynamic_reconfigure
     message_generation
 )
 
@@ -21,6 +22,10 @@ add_message_files(
 add_service_files(
     FILES
     UpdateJSON.srv
+)
+
+generate_dynamic_reconfigure_options(
+    cfg/CandidatesPublisher.cfg
 )
 
 generate_messages(

--- a/jsk_arc2017_common/cfg/CandidatesPublisher.cfg
+++ b/jsk_arc2017_common/cfg/CandidatesPublisher.cfg
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+PACKAGE = 'jsk_arc2017_common'
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("target_location", str_t, 0, "target location", "")
+
+exit(gen.generate(PACKAGE, "jsk_arc2017_common", "CandidatesPublisher"))

--- a/jsk_arc2017_common/node_scripts/candidates_publisher.py
+++ b/jsk_arc2017_common/node_scripts/candidates_publisher.py
@@ -62,7 +62,7 @@ class CandidatesPublisher(ConnectionBasedTransport):
             labels = []
             for label in label_list:
                 label_msg = Label()
-                label_msg.label = label
+                label_msg.id = label
                 label_msg.name = self.label_names[label]
                 labels.append(label_msg)
             msg = LabelArray()

--- a/jsk_arc2017_common/node_scripts/candidates_publisher.py
+++ b/jsk_arc2017_common/node_scripts/candidates_publisher.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import dynamic_reconfigure.server
+from jsk_topic_tools import ConnectionBasedTransport
+import json
+import os.path as osp
+import rospy
+from std_msgs.msg import String
+
+from jsk_arc2017_common.cfg import CandidatesPublisherConfig
+from jsk_recognition_msgs.msg import Label
+from jsk_recognition_msgs.msg import LabelArray
+
+
+class CandidatesPublisher(ConnectionBasedTransport):
+
+    def __init__(self):
+        super(CandidatesPublisher, self).__init__()
+        self.pub = self.advertise(
+            '~output/candidates', LabelArray, queue_size=1)
+        self.srv = dynamic_reconfigure.server.Server(
+            CandidatesPublisherConfig, self._config_cb)
+        self.label_names = rospy.get_param('~label_names')
+
+    def subscribe(self):
+        self.sub = rospy.Subscriber('~input/json_dir', String, self._cb)
+
+    def unsubscribe(self):
+        self.sub.unregister()
+
+    def _config_cb(self, config, level):
+        self.target_location = config.target_location
+        return config
+
+    def _cb(self, msg):
+        json_dir = msg.data
+        if not osp.isdir(json_dir):
+            rospy.logfatal_throttle(
+                10, 'Input json_dir is not directory: %s' % json_dir)
+            return
+        filename = osp.join(json_dir, 'item_location_file.json')
+        if osp.exists(filename):
+            with open(filename) as location_f:
+                data = json.load(location_f)
+
+            bin_contents = {}
+            for bin_ in data['bins']:
+                bin_contents[bin_['bin_id']] = bin_['contents']
+            tote_contents = data['tote']['contents']
+
+            if self.target_location[:3] == 'bin':
+                contents = bin_contents[self.target_location[4]]
+            elif self.target_location == 'tote':
+                contents = tote_contents
+            else:
+                return
+            candidates = ['__background__']
+            candidates = candidates + contents
+            candidates.append('__shelf__')
+            label_list = [self.label_names.index(x) for x in candidates]
+            label_list = sorted(label_list)
+            labels = []
+            for label in label_list:
+                label_msg = Label()
+                label_msg.label = label
+                label_msg.name = self.label_names[label]
+                labels.append(label_msg)
+            msg = LabelArray()
+            msg.labels = labels
+            msg.header.stamp = rospy.Time.now()
+            self.pub.publish(msg)
+
+if __name__ == '__main__':
+    rospy.init_node('candidates_publisher')
+    candidates_publisher = CandidatesPublisher()
+    rospy.spin()

--- a/jsk_arc2017_common/samples/sample_candidates_publisher.launch
+++ b/jsk_arc2017_common/samples/sample_candidates_publisher.launch
@@ -1,0 +1,14 @@
+<launch>
+  <rosparam command="load" file="$(find jsk_arc2017_common)/config/label_names.yaml" ns="label_names" />
+
+  <include file="$(find jsk_arc2017_common)/samples/sample_json_saver.launch" />
+
+  <node name="candidates_publisher"
+      pkg="jsk_arc2017_common" type="candidates_publisher.py" >
+    <remap from="~input/json_dir" to="/json_saver/output/json_dir" />
+    <remap from="~label_names" to="label_names" />
+    <rosparam>
+      target_location: bin_A
+    </rosparam>
+  </node>
+</launch>

--- a/jsk_arc2017_common/test/candidates_publisher.test
+++ b/jsk_arc2017_common/test/candidates_publisher.test
@@ -1,0 +1,10 @@
+<launch>
+  <include file="$(find jsk_arc2017_common)/samples/sample_candidates_publisher.launch" />
+
+  <test test-name="test_candidates_publisher"
+        name="test_candidates_publisher"
+        pkg="jsk_tools"  type="test_topic_published.py" >
+    <param name="~topic_0" value="/candidates_publisher/output/candidates" />
+    <param name="~timeout_0" value="10" />
+  </test>
+</launch>


### PR DESCRIPTION
waiting for upstream
require https://github.com/jsk-ros-pkg/jsk_recognition/pull/2143 
related to https://github.com/start-jsk/jsk_apc/issues/2187

- update candidates for segmentation via topic
- add `candidates_publisher.py` node
- add `:set-target-location` method in `arc-interface.l`