### PR TITLE
Add PointCloudLibrary/pcl to fc.rosinstall

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -50,3 +50,7 @@
     local-name: FA-I-sensor/force_proximity_ros
     uri: https://github.com/knorth55/FA-I-sensor.git
     version: jsk_apc
+- git:
+    local-name: PointCloudLibrary/pcl
+    uri: https://github.com/PointCloudLibrary/pcl.git
+    version: pcl-1.8.0rc2


### PR DESCRIPTION
Building pcl is optional, because I install it to /usr/local in sheeta.
You can try below in your own pc.

```bash
cd PointCloudLibrary/pcl
mkdir -p build
cd build
cmake .. -DCMAKE_INSTALL_PREFIX:PATH=$HOME/catkin_ws/devel -DBUILD_GPU=1
make -j
make install
```