### PR TITLE
Publish scenes and view frame of DatasetV3 in ROS

### DIFF
--- a/jsk_arc2017_common/CMakeLists.txt
+++ b/jsk_arc2017_common/CMakeLists.txt
@@ -29,6 +29,7 @@ add_service_files(
 
 generate_dynamic_reconfigure_options(
     cfg/CandidatesPublisher.cfg
+    cfg/PublishDatasetV3.cfg
 )
 
 generate_messages(

--- a/jsk_arc2017_common/cfg/PublishDatasetV3.cfg
+++ b/jsk_arc2017_common/cfg/PublishDatasetV3.cfg
@@ -1,0 +1,14 @@
+#! /usr/bin/env python
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+
+PACKAGE = 'jsk_arc2017_common'
+ID = 'PublishDatasetV3'
+
+gen = ParameterGenerator()
+
+gen.add('scene_idx', int_t, 0, 'Index of scene.', 0, 0, 10000)
+gen.add('frame_idx', int_t, 0, 'Index of view frame in scene.', 0, 0, 8)
+
+exit(gen.generate(PACKAGE, PACKAGE, ID))

--- a/jsk_arc2017_common/launch/publish_dataset_v3.launch
+++ b/jsk_arc2017_common/launch/publish_dataset_v3.launch
@@ -1,0 +1,40 @@
+<launch>
+
+  <node name="publish_dataset_v3"
+        pkg="jsk_arc2017_common" type="publish_dataset_v3.py">
+    <remap from="~output/rgb/camera_info" to="camera/rgb/camera_info" />
+    <remap from="~output/rgb/image_rect_color" to="camera/rgb/image_rect_color" />
+    <remap from="~output/depth_registered/camera_info" to="camera/depth_registered/camera_info" />
+    <remap from="~output/depth_registered/image_rect" to="camera/depth_registered/image_rect" />
+  </node>
+
+  <group ns="camera/depth_registered">
+    <node name="image_rect_view"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="image_rect" />
+      <rosparam>
+        gui: false
+        colormap: 2
+        min_image_value: 0.5
+        max_image_value: 2.0
+      </rosparam>
+    </node>
+  </group>
+
+  <group ns="camera">
+    <node name="point_cloud_xyzrgb"
+          pkg="nodelet" type="nodelet"
+          args="standalone depth_image_proc/point_cloud_xyzrgb">
+    </node>
+  </group>
+
+  <node name="rviz"
+        pkg="rviz" type="rviz"
+        args="-d $(find jsk_arc2017_common)/rvizconfig/publish_dataset_v3.rviz">
+  </node>
+  <node name="rqt_reconfigure"
+        pkg="rqt_reconfigure" type="rqt_reconfigure"
+        args="publish_dataset_v3">
+  </node>
+
+</launch>

--- a/jsk_arc2017_common/node_scripts/publish_dataset_v3.py
+++ b/jsk_arc2017_common/node_scripts/publish_dataset_v3.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+import os
+import os.path as osp
+
+import numpy as np
+import skimage.io
+import yaml
+
+import cv_bridge
+import dynamic_reconfigure.server
+from geometry_msgs.msg import TransformStamped
+import genpy.message
+import rospy
+from sensor_msgs.msg import CameraInfo
+from sensor_msgs.msg import Image
+from std_msgs.msg import Header
+import tf
+
+from jsk_arc2017_common.cfg import PublishDatasetV3Config
+
+
+class DatasetCollectedOnShelfMultiViewScenes(object):
+
+    def __init__(self):
+        self.scene_ids = []
+        self.root = '/data/projects/arc2017/datasets/JSKV3_scenes'
+        for scene_id in sorted(os.listdir(self.root)):
+            self.scene_ids.append(scene_id)
+
+    def __len__(self):
+        return len(self.scene_ids)
+
+    def get_frame(self, scene_idx, frame_idx=0):
+        assert 0 <= scene_idx < len(self.scene_ids)
+        assert 0 <= frame_idx < 9
+        scene_id = self.scene_ids[scene_idx]
+        scene_dir = osp.join(self.root, scene_id)
+        frame_dirs = sorted(os.listdir(scene_dir))
+        frame_dir = osp.join(scene_dir, frame_dirs[frame_idx])
+
+        frame_id = int(
+            open(osp.join(frame_dir, 'view_frame.txt')).read().strip())
+        assert frame_id == frame_idx + 1
+        img = skimage.io.imread(osp.join(frame_dir, 'image.jpg'))
+        depth = np.load(osp.join(frame_dir, 'depth.npz'))['arr_0']
+        camera_info = yaml.load(
+            open(osp.join(frame_dir,
+                          'camera_info_right_hand_camera_left.yaml')))
+        tf_camera_from_base = yaml.load(
+            open(osp.join(frame_dir, 'tf_camera_rgb_from_base.yaml')))
+
+        return frame_id, img, depth, camera_info, tf_camera_from_base
+
+
+class PublishDatasetV3(object):
+
+    def __init__(self):
+        self._dataset = DatasetCollectedOnShelfMultiViewScenes()
+
+        self._config_srv = dynamic_reconfigure.server.Server(
+            PublishDatasetV3Config, self._config_cb)
+
+        self.pub_rgb = rospy.Publisher(
+            '~output/rgb/image_rect_color', Image, queue_size=1)
+        self.pub_rgb_cam_info = rospy.Publisher(
+            '~output/rgb/camera_info', CameraInfo, queue_size=1)
+        self.pub_depth = rospy.Publisher(
+            '~output/depth_registered/image_rect', Image, queue_size=1)
+        self.pub_depth_cam_info = rospy.Publisher(
+            '~output/depth_registered/camera_info', CameraInfo, queue_size=1)
+
+        self.tf_broadcaster = tf.broadcaster.TransformBroadcaster()
+        self._timer = rospy.Timer(rospy.Duration(1. / 30), self._timer_cb)
+
+    def _config_cb(self, config, level):
+        self._scene_idx = config.scene_idx
+        self._frame_idx = config.frame_idx
+        return config
+
+    def _timer_cb(self, event):
+        img, depth, cam_info, tf = self._dataset.get_frame(
+            self._scene_idx, self._frame_idx)[1:5]
+
+        cam_info_msg = CameraInfo()
+        genpy.message.fill_message_args(cam_info_msg, cam_info)
+        cam_info_msg.header.stamp = event.current_real
+
+        tf_msg = TransformStamped()
+        genpy.message.fill_message_args(tf_msg, tf)
+        tf_msg.header.stamp = event.current_real
+
+        bridge = cv_bridge.CvBridge()
+
+        imgmsg = bridge.cv2_to_imgmsg(img, encoding='rgb8')
+        imgmsg.header.frame_id = cam_info_msg.header.frame_id
+        imgmsg.header.stamp = event.current_real
+
+        depth_msg = bridge.cv2_to_imgmsg(depth, encoding='32FC1')
+        depth_msg.header.frame_id = cam_info_msg.header.frame_id
+        depth_msg.header.stamp = event.current_real
+
+        self.tf_broadcaster.sendTransformMessage(tf_msg)
+        self.pub_rgb.publish(imgmsg)
+        self.pub_rgb_cam_info.publish(cam_info_msg)
+        self.pub_depth.publish(depth_msg)
+        self.pub_depth_cam_info.publish(cam_info_msg)
+
+
+if __name__ == '__main__':
+    rospy.init_node('publish_dataset_v3')
+    app = PublishDatasetV3()
+    rospy.spin()

--- a/jsk_arc2017_common/rvizconfig/publish_dataset_v3.rviz
+++ b/jsk_arc2017_common/rvizconfig/publish_dataset_v3.rviz
@@ -1,0 +1,202 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 156
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.03
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /camera/rgb/image_rect_color
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.01
+      Style: Points
+      Topic: /camera/depth_registered/points
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: jsk_rviz_plugin/CameraInfo
+      Enabled: true
+      Image Topic: ""
+      Name: CameraInfo
+      Topic: /camera/rgb/camera_info
+      Unreliable: false
+      Value: true
+      alpha: 1
+      color: 85; 255; 255
+      edge color: 125; 125; 125
+      far clip: 0.1
+      not show side polygons: true
+      show edges: true
+      show polygons: true
+      use image: false
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base:
+          Value: true
+        right_hand_left_camera_rgb_optical_frame:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        base:
+          right_hand_left_camera_rgb_optical_frame:
+            {}
+      Update Interval: 0
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /camera/depth_registered/image_rect_view/output
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Depth
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 182; 182; 182
+    Fixed Frame: base
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 1.85143
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.06
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.634931
+        Y: 0.200494
+        Z: -0.0194497
+      Name: Current View
+      Near Clip Distance: 0.01
+      Pitch: 0.660398
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 1.89538
+    Saved: ~
+Window Geometry:
+  Depth:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 915
+  Hide Left Dock: false
+  Hide Right Dock: true
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000309fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000000dd000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065010000010b000000fa0000001600fffffffb0000000a00440065007000740068010000020b000001260000001600ffffff000000010000010f00000309fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002800000309000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000055a0000003efc0100000002fb0000000800540069006d006501000000000000055a000002f600fffffffb0000000800540069006d00650100000000000004500000000000000000000003ea0000030900000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1370
+  X: 394
+  Y: 252

--- a/jsk_arc2017_common/scripts/create_scenes_dataset_v3.py
+++ b/jsk_arc2017_common/scripts/create_scenes_dataset_v3.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+import os
+import os.path as osp
+import shutil
+
+# import cv2
+import numpy as np
+import skimage.io
+import yaml
+
+import cv_bridge
+from geometry_msgs.msg import TransformStamped
+import genpy.message
+import rospy
+from sensor_msgs.msg import CameraInfo
+from sensor_msgs.msg import Image
+from std_msgs.msg import Header
+import tf
+
+
+class DatasetCollectedOnShelfMultiView(object):
+
+    def __init__(self):
+        self.ids = []
+        self.root = '/data/projects/arc2017/datasets/JSKV3'
+        for id_ in sorted(os.listdir(self.root)):
+            self.ids.append(id_)
+
+    def __len__(self):
+        return len(self.ids)
+
+    def __getitem__(self, i):
+        id_ = self.ids[i]
+        data_dir = osp.join(self.root, id_)
+
+        frame_idx = int(
+            open(osp.join(data_dir, 'view_frame.txt')).read().strip())
+        img = skimage.io.imread(osp.join(data_dir, 'image.jpg'))
+        depth = np.load(osp.join(data_dir, 'depth.npz'))['arr_0']
+        camera_info = yaml.load(
+            open(osp.join(data_dir,
+                          'camera_info_right_hand_camera_left.yaml')))
+        tf_camera_from_base = yaml.load(
+            open(osp.join(data_dir, 'tf_camera_rgb_from_base.yaml')))
+
+        return frame_idx, img, depth, camera_info, tf_camera_from_base
+
+
+def main():
+    dataset = DatasetCollectedOnShelfMultiView()
+
+    out_dir = '/data/projects/arc2017/datasets/JSKV3_scenes'
+    if not osp.exists(out_dir):
+        os.makedirs(out_dir)
+
+    scene_idx = 0
+    for i in xrange(len(dataset)):
+        frame_idx, img, depth = dataset[i][:3]
+        if frame_idx == 1:
+            scene_idx += 1
+
+        scene_dir = osp.join(out_dir, 'scene-%04d' % scene_idx)
+        if not osp.exists(scene_dir):
+            os.makedirs(scene_dir)
+
+        frame_dir = osp.join(dataset.root, dataset.ids[i])
+        shutil.copytree(frame_dir, osp.join(scene_dir, dataset.ids[i]))
+        print('%s -> %s' % (frame_dir, osp.join(scene_dir, dataset.ids[i])))
+
+        # cv2.imshow('create_scenes_dataset_v3', img[:, :, ::-1])
+        # k = cv2.waitKey(0)
+        # if k == ord('q'):
+        #     break
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
```
roslaunch jsk_arc2017_baxter baxter.launch moveit:=false
roslaunch jsk_arc2017_baxter stereo_astra_hand.launch
roslaunch jsk_arc2017_baxter collect_data_in_shelf.launch
....
rsync -avt ~/.ros/jsk_arc2017_baxter/dataset_jsk_v3 /data/projects/arc2017/datasets/JSKV3
rosrun jsk_arc2017_common create_scenes_dataset_v3.py
roslaunch jsk_arc2017_baxter publish_dataset_v3.launch
```

![](https://user-images.githubusercontent.com/4310419/27838667-2178ee9c-6127-11e7-85e7-7bc5e8fb676f.gif)

Part of https://github.com/start-jsk/jsk_apc/pull/2217