### PR TITLE
Always set graspingp of pinching as true

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
@@ -397,7 +397,7 @@
                   :rotation-axis :z)
             3000 (send *ri* :get-arm-controller arm) 0)
       (send *ri* :wait-interpolation-until-grasp arm)
-      (setq graspingp (send *ri* :graspingp arm))
+      (setq graspingp (send *ri* :graspingp arm :suction))
       (ros::ros-info "[:try-to-suction-object-with-gripper-v4] arm:~a graspingp: ~a" arm graspingp)
       (unless graspingp
         (ros::ros-info "[:try-to-suction-object-with-gripper-v4] arm:~a again approach to the object" arm)
@@ -417,7 +417,7 @@
             3000 (send *ri* :get-arm-controller arm) 0)
       (send *ri* :wait-interpolation)
       (unix::sleep 1)  ;; wait for arm to follow
-      (setq graspingp (send *ri* :graspingp arm))
+      (setq graspingp (send *ri* :graspingp arm :suction))
       (ros::ros-info "[:try-to-suction-object-with-gripper-v4] arm:~a graspingp: ~a" arm graspingp)
       graspingp))
   (:try-to-suction-object-with-gripper-v6
@@ -452,7 +452,7 @@
                   :rotation-axis :z)
             3000 (send *ri* :get-arm-controller arm) 0)
       (send *ri* :wait-interpolation-until arm :grasp :prismatic-loaded)
-      (setq graspingp (send *ri* :graspingp arm))
+      (setq graspingp (send *ri* :graspingp arm :suction))
       (ros::ros-info "[:try-to-suction-object-with-gripper-v6] arm:~a graspingp: ~a" arm graspingp)
       (unless graspingp
         (ros::ros-info "[:try-to-suction-object-with-gripper-v6] arm:~a again approach to the object" arm)
@@ -475,7 +475,7 @@
             3000 (send *ri* :get-arm-controller arm) 0)
       (send *ri* :wait-interpolation)
       (unix::sleep 1)  ;; wait for arm to follow
-      (setq graspingp (send *ri* :graspingp arm))
+      (setq graspingp (send *ri* :graspingp arm :suction))
       (ros::ros-info "[:try-to-suction-object-with-gripper-v6] arm:~a graspingp: ~a" arm graspingp)
       graspingp))
   (:try-to-pinch-object
@@ -515,7 +515,7 @@
       (send *baxter* :angle-vector (send *ri* :state :potentio-vector :wait-until-update t))
       (send *ri* :start-grasp arm :pinch)
       (send *baxter* :angle-vector (send *ri* :state :potentio-vector :wait-until-update t))
-      (setq graspingp (send *ri* :graspingp arm))
+      (setq graspingp (send *ri* :graspingp arm :pinch))
       (ros::ros-info "[:try-to-pinch-object] arm:~a graspingp: ~a" arm graspingp)
       ;; lift object
       (ros::ros-info "[:try-to-pinch-object] arm:~a lift the object" arm)
@@ -523,7 +523,7 @@
             3000 (send *ri* :get-arm-controller arm :gripper nil) 0)
       (send *ri* :wait-interpolation)
       (unix::sleep 1)  ;; wait for arm to follow
-      (setq graspingp (send *ri* :graspingp arm))
+      (setq graspingp (send *ri* :graspingp arm :pinch))
       (ros::ros-info "[:try-to-pinch-object] arm:~a graspingp: ~a" arm graspingp)
       graspingp))
   (:ik->bin-center

--- a/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
@@ -387,8 +387,8 @@
         (format nil "/gripper_front/limb/~a/servo/torque" l/r)
         (instance std_msgs::Bool :init :data nil))))
   (:graspingp
-    (arm &optional type)
-    (let (topic finger-av fingerp)
+    (arm &optional (type :suction))
+    (let (topic finger-av pinchingp)
       (if (ros::get-param "/apc_on_gazebo" nil)
         (progn
           (setq topic (format nil "/robot/~a_vacuum_gripper/grasping" (arm-to-str arm)))
@@ -396,13 +396,15 @@
           )
         (progn
           (setq finger-av (send self :get-real-finger-av arm))
-          (setq fingerp
-                (and (or
-                       (and (< (aref finger-av 0) 45) (< (aref finger-av 1) 80))
-                       (and (>= (aref finger-av 0) 45) (< (aref finger-av 1) 155)))
-                     (> (send self :get-finger-load arm) 0.55)))
+          ;; FIXME: cannot detect grasping small objects
+          ;; (setq pinchingp
+          ;;       (and (or
+          ;;              (and (< (aref finger-av 0) 45) (< (aref finger-av 1) 80))
+          ;;              (and (>= (aref finger-av 0) 45) (< (aref finger-av 1) 155)))
+          ;;            (> (send self :get-finger-load arm) 0.55)))
+          (setq pinchingp t)
           (send self :spin-once)
-          (or (if (not (eq type :suction)) fingerp nil)
+          (or (if (not (eq type :suction)) pinchingp nil)
               (if (not (eq type :pinch))
                 (< (gethash arm pressure-)
                    (cond

--- a/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
@@ -388,7 +388,7 @@
         (instance std_msgs::Bool :init :data nil))))
   (:graspingp
     (arm &optional (type :suction))
-    (let (topic finger-av pinchingp)
+    (let (topic finger-av suctioningp pinchingp)
       (if (ros::get-param "/apc_on_gazebo" nil)
         (progn
           (setq topic (format nil "/robot/~a_vacuum_gripper/grasping" (arm-to-str arm)))
@@ -396,6 +396,11 @@
           )
         (progn
           (setq finger-av (send self :get-real-finger-av arm))
+          (setq suctioningp
+                (< (gethash arm pressure-)
+                   (cond
+                     ((eq arm :rarm) rarm-pressure-threshold-)
+                     ((eq arm :larm) larm-pressure-threshold-))))
           ;; FIXME: cannot detect grasping small objects
           ;; (setq pinchingp
           ;;       (and (or
@@ -404,13 +409,10 @@
           ;;            (> (send self :get-finger-load arm) 0.55)))
           (setq pinchingp t)
           (send self :spin-once)
-          (or (if (not (eq type :suction)) pinchingp nil)
-              (if (not (eq type :pinch))
-                (< (gethash arm pressure-)
-                   (cond
-                     ((eq arm :rarm) rarm-pressure-threshold-)
-                     ((eq arm :larm) larm-pressure-threshold-)))
-                nil))))))
+          (cond ((eq type :suction) suctioningp)
+                ((eq type :pinch) pinchingp)
+                ((null type) (or suctioningp pinchingp))
+                (t (ros::ros-error "Unsupported type for :graspingp") (exit)))))))
   (:arm-potentio-vector
     (arm)
     (case arm

--- a/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
@@ -130,7 +130,7 @@
             3000 (send *ri* :get-arm-controller arm :gripper nil) 0))
     (send *ri* :wait-interpolation)
     (when moveit-p (send self :delete-shelf-scene))
-    (setq graspingp (send *ri* :graspingp arm))
+    (setq graspingp (send *ri* :graspingp arm grasp-style))
     (ros::ros-info "[main] arm: ~a graspingp: ~a" arm graspingp)
     graspingp)
   (:return-from-pick-object (arm)
@@ -233,7 +233,7 @@
         (send *ri* :angle-vector-sequence-raw avs 4000
               (send *ri* :get-arm-controller arm :gripper nil :head t) 0))
       (send *ri* :wait-interpolation)
-      (setq dropped (not (send *ri* :graspingp arm)))
+      (setq dropped (not (send *ri* :graspingp arm grasp-style)))
       (if dropped
         (progn
           (ros::ros-error "[main] arm ~a: dropped object" arm)

--- a/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
@@ -118,7 +118,7 @@
             3000 (send *ri* :get-arm-controller arm :gripper nil) 0))
     (send *ri* :wait-interpolation)
     (when moveit-p (send self :delete-tote-scene arm))
-    (setq graspingp (send *ri* :graspingp arm))
+    (setq graspingp (send *ri* :graspingp arm grasp-style))
     (ros::ros-info "[main] arm: ~a graspingp: ~a" arm graspingp)
     graspingp)
   (:return-from-pick-object (arm)
@@ -199,7 +199,7 @@
                     :offset #f(0 0 300) :rotation-axis nil :move-palm-end t)
               4000 (send *ri* :get-arm-controller arm :gripper nil :head t) 0))
       (send *ri* :wait-interpolation)
-      (setq dropped (not (send *ri* :graspingp arm)))
+      (setq dropped (not (send *ri* :graspingp arm grasp-style)))
       (if dropped
         (progn
           (ros::ros-error "[main] arm ~a: dropped object" arm)


### PR DESCRIPTION
For #2210 
My idea is we can detect some object is picked by weight scales in `verify-object`.
So we can skip grasping checks of `:try-to-pinch-object` by making `:graspingp` return t when `:pinch` is set.