### PR TITLE
Re-calibrate left vacuum pad joint

### DIFF
--- a/jsk_arc2017_baxter/config/left_gripper_v6/dxl_controllers.yaml
+++ b/jsk_arc2017_baxter/config/left_gripper_v6/dxl_controllers.yaml
@@ -24,9 +24,9 @@ vacuum_pad_tendon_controller:
   joint_torque_limit: 0.4
   motor:
     id: 4
-    init: 570
-    min: 120
-    max: 1023
+    init: 500
+    min: 0
+    max: 1000
 finger_yaw_joint_controller:
   controller:
     package: dynamixel_controllers


### PR DESCRIPTION
Tendon becomes longer than initial state.
Perhaps the length of tendon will become further longer, but become stable soon like right gripper.