### PR TITLE
Update hand action state in :hand-interpolatingp

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
@@ -221,6 +221,7 @@
   (:cancel-move-hand (arm)
     (send (gethash arm hand-actions-) :cancel-goal))
   (:hand-interpolatingp (arm)
+    (send self :spin-once)
     (eq (send (gethash arm hand-actions-) :get-state) ros::*simple-goal-state-active*))
   (:get-finger-flex (arm side)
     (send self :spin-once)


### PR DESCRIPTION
This prevents `:hand-interpolatingp` from returning `nil` while hand motion is executed.
(following https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/master/pr2eus/robot-interface.l#L595)