### PR TITLE
Fix larm IK to accept :use-gripper nil

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/baxter.l
+++ b/jsk_arc2017_baxter/euslisp/lib/baxter.l
@@ -95,7 +95,7 @@
       (cond ((equal (send (car (last link-list)) :name) "right_gripper_pad_with_base")
              (setq link-list (butlast link-list 2)))
             ((equal (send (car (last link-list)) :name) "left_gripper_pad_with_base")
-             (setq link-list (butlast link-list))))
+             (setq link-list (butlast link-list 2))))
       nil)
     (send-super* :inverse-kinematics target-coords
                  :move-target move-target :link-list link-list :rthre rthre args)


### PR DESCRIPTION
I forgot to fix this in #2232 
Without this fix, we found that prismatic joint in left gripper moves by IK even if we set `:use-gripper nil`