### PR TITLE
Remove released repos from .travis.rosinstall

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,13 +1,12 @@
-# jsk_robot: will be removed after the release of 1.0.10
-- git:
-    local-name: jsk-ros-pkg/jsk_robot
-    uri: https://github.com/jsk-ros-pkg/jsk_robot.git
-    version: c978f3da06261c77e0dafea2f2e4df072323b555
+# - git:
+#     local-name: jsk-ros-pkg/jsk_robot
+#     uri: https://github.com/jsk-ros-pkg/jsk_robot.git
+#     version: c978f3da06261c77e0dafea2f2e4df072323b555
 - git:
     local-name: FA-I-sensor/force_proximity_ros
     uri: https://github.com/knorth55/FA-I-sensor.git
     version: jsk_apc
-- git:
-    local-name: jsk-ros-pkg/jsk_recognition
-    uri: https://github.com/jsk-ros-pkg/jsk_recognition.git
-    version: d774854420af82fe9ea16319d743a2b465d63d78
+# - git:
+#     local-name: jsk-ros-pkg/jsk_recognition
+#     uri: https://github.com/jsk-ros-pkg/jsk_recognition.git
+#     version: d774854420af82fe9ea16319d743a2b465d63d78


### PR DESCRIPTION
For faster CI testing.