### PR TITLE
Enable data collection in tote

### DIFF
--- a/jsk_arc2017_baxter/experiments/create_dataset2d/README.md
+++ b/jsk_arc2017_baxter/experiments/create_dataset2d/README.md
@@ -12,6 +12,16 @@ rosrun jsk_arc2017_common view_dataset2d.py ~/.ros/jsk_arc2017_baxter/create_dat
 ![](https://user-images.githubusercontent.com/4310419/28227820-ac70352c-6916-11e7-8a95-277f913cd9e9.gif)
 
 
+## Collect raw data on tote bin
+
+```bash
+roslaunch jsk_arc2017_baxter baxter.launch moveit:=false pick:=false
+roslaunch jsk_arc2017_baxter stereo_astra_hand.launch
+roslaunch jsk_arc2017_baxter create_dataset2d_rawdata_main.launch box:=tote
+rosrun jsk_arc2017_common view_dataset2d.py ~/.ros/jsk_arc2017_baxter/create_dataset2d/right_hand
+```
+
+
 ## Annotate
 
 ```bash

--- a/jsk_arc2017_baxter/experiments/create_dataset2d/create-dataset2d-collect-rawdata-main.l
+++ b/jsk_arc2017_baxter/experiments/create_dataset2d/create-dataset2d-collect-rawdata-main.l
@@ -8,22 +8,22 @@
 
 ;; Parameters
 ;; ==========
-(setq boxes (ros::get-param "~boxes" "bin"))
+(setq box-type (ros::get-param "~box_type" "bin"))
 (let ((side (ros::get-param "~side" "right")))
   (cond ((string= side "both") (setq *arms* '(:larm :rarm)))
         ((string= side "left") (setq *arms* '(:larm)))
         ((string= side "right") (setq *arms* '(:rarm)))
         )
-  (ros::ros-info-green "Collect rawdata for creating dataset2d in ~a boxes, using ~a hand" boxes side)
+  (ros::ros-info-green "Collect rawdata for creating dataset2d in [~a] boxes, using ~a hand" box-type side)
   )
 
 ;; Main
 ;; ====
 (jsk_arc2017_baxter::arc-init :ctype :default-controller :moveit nil)
 (objects (list *baxter*))
-(cond ((string= boxes "bin") (send *ti* :recognize-bin-boxes))
-      ((string= boxes "tote") (send *ti* :recognize-tote-boxes))
-      (t (ros::ros-info-red "Invalid input rosparam \"boxes\". Use \"bin\" or \"tote\"."))
+(cond ((string= box-type "bin") (send *ti* :recognize-bin-boxes))
+      ((string= box-type "tote") (send *ti* :recognize-tote-boxes))
+      (t (ros::ros-info-red "Invalid input rosparam ~box_type. Use \"bin\" or \"tote\"."))
       )
 
 (defun rqt_yn_btn (&key (message ""))
@@ -32,26 +32,26 @@
     (ros::wait-for-service "rqt_yn_btn")
     (send (ros::service-call "rqt_yn_btn" req) :yes)))
 
-(ros::ros-info-green "Start collecting raw data in ~a" boxes)
+(ros::ros-info-green "Start collecting raw data in ~a" box-type)
 (while
   t
   (let ((bins '(:a :b :c)) (totes '(:tote)) bins-or-totes)
     (when (rqt_yn_btn :message "Can I collect rawdata?")
-      (setq bins-or-totes (cond ((string= boxes "bin") bins)
-                                ((string= boxes "tote") totes)
+      (setq bins-or-totes (cond ((string= box-type "bin") bins)
+                                ((string= box-type "tote") totes)
                                 ))
       (dolist (bin-or-tote bins-or-totes)
-        (let ((arm (cond ((string= boxes "bin") (if (eq bin-or-tote :a) :larm :rarm))
-                         ((string= boxes "tote") :rarm)
+        (let ((arm (cond ((string= box-type "bin") (if (eq bin-or-tote :a) :larm :rarm))
+                         ((string= box-type "tote") :rarm)
                          )))
           (when (find arm *arms*)
-            (ros::set-param (format nil "/~a_hand/target_~a_name" (arm-to-str arm) boxes)
+            (ros::set-param (format nil "/~a_hand/target_~a_name" (arm-to-str arm) box-type)
                             (symbol2str bin-or-tote))
             (ros::set-param (format nil "/~a_hand/view_frame" (arm-to-str arm)) "default")
 
             ;; overlook the target box
-            (cond ((string= boxes "bin") (send *ti* :move-arm-body->bin-overlook-pose arm bin-or-tote))
-                  ((string= boxes "tote") (send *ti* :move-arm-body->tote-overlook-pose arm))
+            (cond ((string= box-type "bin") (send *ti* :move-arm-body->bin-overlook-pose arm bin-or-tote))
+                  ((string= box-type "tote") (send *ti* :move-arm-body->tote-overlook-pose arm))
                   )
             (send *ri* :wait-interpolation)
 

--- a/jsk_arc2017_baxter/experiments/create_dataset2d/create-dataset2d-collect-rawdata-main.l
+++ b/jsk_arc2017_baxter/experiments/create_dataset2d/create-dataset2d-collect-rawdata-main.l
@@ -8,19 +8,23 @@
 
 ;; Parameters
 ;; ==========
+(setq boxes (ros::get-param "~boxes" "bin"))
 (let ((side (ros::get-param "~side" "right")))
   (cond ((string= side "both") (setq *arms* '(:larm :rarm)))
         ((string= side "left") (setq *arms* '(:larm)))
         ((string= side "right") (setq *arms* '(:rarm)))
         )
-  (ros::ros-info-green "Collect rawdata for creating dataset2d using ~a hand" side)
+  (ros::ros-info-green "Collect rawdata for creating dataset2d in ~a boxes, using ~a hand" boxes side)
   )
 
 ;; Main
 ;; ====
 (jsk_arc2017_baxter::arc-init :ctype :default-controller :moveit nil)
 (objects (list *baxter*))
-(send *ti* :recognize-bin-boxes)
+(cond ((string= boxes "bin") (send *ti* :recognize-bin-boxes))
+      ((string= boxes "tote") (send *ti* :recognize-tote-boxes))
+      (t (ros::ros-info-red "Invalid input rosparam \"boxes\". Use \"bin\" or \"tote\"."))
+      )
 
 (defun rqt_yn_btn (&key (message ""))
   (let ((req (instance jsk_gui_msgs::YesNoRequest :init)))
@@ -28,20 +32,27 @@
     (ros::wait-for-service "rqt_yn_btn")
     (send (ros::service-call "rqt_yn_btn" req) :yes)))
 
-(ros::ros-info-green "Start collecting raw data in bins")
+(ros::ros-info-green "Start collecting raw data in ~a" boxes)
 (while
   t
-  (let ((bins '(:a :b :c)))
-    (when (rqt_yn_btn :message "Can I collect rawdata from bins?")
-      (dolist (bin bins)
-        (let ((arm (if (eq bin :a) :larm :rarm)))
+  (let ((bins '(:a :b :c)) (totes '(:tote)) bins-or-totes)
+    (when (rqt_yn_btn :message "Can I collect rawdata?")
+      (setq bins-or-totes (cond ((string= boxes "bin") bins)
+                                ((string= boxes "tote") totes)
+                                ))
+      (dolist (bin-or-tote bins-or-totes)
+        (let ((arm (cond ((string= boxes "bin") (if (eq bin-or-tote :a) :larm :rarm))
+                         ((string= boxes "tote") :rarm)
+                         )))
           (when (find arm *arms*)
-            (ros::set-param (format nil "/~a_hand/target_bin_name" (arm-to-str arm))
-                            (symbol2str bin))
+            (ros::set-param (format nil "/~a_hand/target_~a_name" (arm-to-str arm) boxes)
+                            (symbol2str bin-or-tote))
             (ros::set-param (format nil "/~a_hand/view_frame" (arm-to-str arm)) "default")
 
-            ;; overlook the target bin
-            (send *ti* :move-arm-body->bin-overlook-pose arm bin)
+            ;; overlook the target box
+            (cond ((string= boxes "bin") (send *ti* :move-arm-body->bin-overlook-pose arm bin-or-tote))
+                  ((string= boxes "tote") (send *ti* :move-arm-body->tote-overlook-pose arm))
+                  )
             (send *ri* :wait-interpolation)
 
             ;; request saving raw data

--- a/jsk_arc2017_baxter/experiments/create_dataset2d/create_dataset2d_collect_rawdata_main.launch
+++ b/jsk_arc2017_baxter/experiments/create_dataset2d/create_dataset2d_collect_rawdata_main.launch
@@ -26,7 +26,7 @@
     <env name="DISPLAY" value="" />
     <rosparam subst_value="True">
       side: right
-      boxes: $(arg box)
+      box_type: $(arg box)
     </rosparam>
   </node>
 

--- a/jsk_arc2017_baxter/experiments/create_dataset2d/create_dataset2d_collect_rawdata_main.launch
+++ b/jsk_arc2017_baxter/experiments/create_dataset2d/create_dataset2d_collect_rawdata_main.launch
@@ -2,17 +2,21 @@
 
   <!-- **********************************************************************************************
        Usage:
-         roslaunch jsk_arc2017_baxter baxter.launch moveit:=false pick:=true
+         roslaunch jsk_arc2017_baxter baxter.launch moveit:=false pick:=true (or false)
          roslaunch jsk_arc2017_baxter stereo_astra_hand.launch
-         roslaunch jsk_arc2017_baxter create_dataset2d_collect_rawdata_main.launch
+         roslaunch jsk_arc2017_baxter create_dataset2d_collect_rawdata_main.launch box:=bin (or tote)
        ********************************************************************************************** -->
+
+  <arg name="box" default="bin" doc="Bin or tote" />
 
   <!-- Data collection server -->
   <include file="$(find jsk_arc2017_baxter)/experiments/create_dataset2d/create_dataset2d_data_collection_server.launch">
     <arg name="side" value="left" />
+    <arg name="box" value="$(arg box)" />
   </include>
   <include file="$(find jsk_arc2017_baxter)/experiments/create_dataset2d/create_dataset2d_data_collection_server.launch">
     <arg name="side" value="right" />
+    <arg name="box" value="$(arg box)" />
   </include>
 
   <!-- Main -->
@@ -20,8 +24,9 @@
         pkg="jsk_arc2017_baxter" type="create-dataset2d-collect-rawdata-main.l"
         output="screen">
     <env name="DISPLAY" value="" />
-    <rosparam>
+    <rosparam subst_value="True">
       side: right
+      boxes: $(arg box)
     </rosparam>
   </node>
 

--- a/jsk_arc2017_baxter/experiments/create_dataset2d/create_dataset2d_data_collection_server.launch
+++ b/jsk_arc2017_baxter/experiments/create_dataset2d/create_dataset2d_data_collection_server.launch
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="side" doc="Left or right" />
+  <arg name="box" doc="Bin or tote" />
 
   <group ns="$(arg side)_hand">
     <node name="data_collection_server"
@@ -31,8 +32,8 @@
             fname: tf_camera_rgb_from_base.yaml
             savetype: YAML
         params:
-          - key: /$(arg side)_hand/target_bin_name
-            fname: shelf_bin.txt
+          - key: /$(arg side)_hand/target_$(arg box)_name
+            fname: shelf_$(arg box).txt
             savetype: Text
           - key: /$(arg side)_hand/view_frame
             fname: view_frame.txt


### PR DESCRIPTION
Update version of #2289.
Enabled data collection in Tote, as well as in Shelf bin.

## Collect raw data

- In Shelf bins

```bash
roslaunch jsk_arc2017_baxter baxter.launch moveit:=false
roslaunch jsk_arc2017_baxter stereo_astra_hand.launch
roslaunch jsk_arc2017_baxter create_dataset2d_rawdata_main.launch
rosrun jsk_arc2017_common view_dataset2d.py ~/.ros/jsk_arc2017_baxter/create_dataset2d/right_hand
```

- In Tote

```bash
roslaunch jsk_arc2017_baxter baxter.launch moveit:=false pick:=false
roslaunch jsk_arc2017_baxter stereo_astra_hand.launch
roslaunch jsk_arc2017_baxter create_dataset2d_rawdata_main.launch box:=tote
rosrun jsk_arc2017_common view_dataset2d.py ~/.ros/jsk_arc2017_baxter/create_dataset2d/right_hand
```
![image](https://user-images.githubusercontent.com/22876283/28349091-a3973514-6c7b-11e7-82da-b49367442d21.jpg)
![depth_viz](https://user-images.githubusercontent.com/22876283/28349092-a5cee62e-6c7b-11e7-9a75-f64906fb3b16.jpg)

