### PR TITLE
increase weight error for pick task

### DIFF
--- a/jsk_arc2017_baxter/launch/setup/setup_for_pick.launch
+++ b/jsk_arc2017_baxter/launch/setup/setup_for_pick.launch
@@ -83,7 +83,8 @@
           - /scale1/output
           - /scale2/output
           - /scale3/output
-        error: 10.0
+        # FIXME: error for hose weight
+        error: 20.0
       </rosparam>
     </node>
   </group>
@@ -138,7 +139,8 @@
           - /scale1/output
           - /scale2/output
           - /scale3/output
-        error: 10.0
+        # FIXME: error for hose weight
+        error: 20.0
       </rosparam>
     </node>
   </group>


### PR DESCRIPTION
increase weight error.
I tried pick task, and hose weight is around 10-20g.
so I increase error to 20g.
this is temporary solution, so I added FIXME comment.