### PR TITLE
Fix load direction of dynamixel motors

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
@@ -408,7 +408,7 @@
           ;;       (and (or
           ;;              (and (< (aref finger-av 0) 45) (< (aref finger-av 1) 80))
           ;;              (and (>= (aref finger-av 0) 45) (< (aref finger-av 1) 155)))
-          ;;            (> (send self :get-finger-load arm) 0.55)))
+          ;;            (< (send self :get-finger-load arm) -0.55)))
           (setq pinchingp t)
           (send self :spin-once)
           (cond ((eq type :suction) suctioningp)
@@ -499,7 +499,7 @@
         (pushback
           #'(lambda ()
               (setq finger-load (send self :get-finger-load arm))
-              (if (> finger-load (+ init-load 0.01))
+              (if (< finger-load (- init-load 0.01))
                 (progn
                   (ros::ros-info "[:wait-interpolation-until] Detected finger loaded load: ~a"
                                  finger-load)
@@ -511,7 +511,7 @@
         (pushback
           #'(lambda ()
               (setq finger-load (send self :get-finger-load arm))
-              (if (< finger-load (- init-load 0.01))
+              (if (> finger-load (+ init-load 0.01))
                 (progn
                   (ros::ros-info "[:wait-interpolation-until] Detected finger unloaded load: ~a"
                                  finger-load)

--- a/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
@@ -21,6 +21,7 @@
           finger-flex-
           finger-load-
           prismatic-load-
+          prismatic-vel-
           proximities-
           proximity-init-values-))
 


### PR DESCRIPTION
Depends on https://github.com/pazeshun/dynamixel_motor/pull/4 (Copy of https://github.com/arebgun/dynamixel_motor/pull/78)
For #2328

## Changes
- (In https://github.com/pazeshun/dynamixel_motor/pull/3) Adjust plus and minus of load and velocity to position of dynamixel motor
- Adjust load direction in `baxter-interface` to the direction fixed in https://github.com/pazeshun/dynamixel_motor/pull/3


