### PR TITLE
Use class segmentation in known objects

### DIFF
--- a/jsk_arc2017_common/launch/object_segmentation_3d.launch
+++ b/jsk_arc2017_common/launch/object_segmentation_3d.launch
@@ -18,7 +18,7 @@
     <arg name="BACKEND" value="chainer" />
     <arg name="GPU" value="$(arg GPU)" />
     <arg name="MODEL_NAME" value="fcn32s" />
-    <arg name="MODEL_FILE" value="$(find jsk_arc2017_common)/data/models/fcn32s_arc2017_datasetv2_cfg003_20170704.npz" />
+    <arg name="MODEL_FILE" value="$(find jsk_arc2017_common)/data/models/fcn32s_arc2017_datasetv2_cfg003_20170612.npz" />
     <arg name="LABEL_YAML" value="$(find jsk_arc2017_common)/config/label_names.yaml" />
     <arg name="USE_PCA" value="true" />
     <arg name="USE_TOPIC" value="true" />

--- a/jsk_arc2017_common/samples/sample_fcn_object_segmentation.launch
+++ b/jsk_arc2017_common/samples/sample_fcn_object_segmentation.launch
@@ -23,6 +23,7 @@
     <arg name="NODELET_MANAGER" value="$(arg NODELET_MANAGER)" />
     <arg name="INPUT_IMAGE" value="$(arg INPUT_IMAGE)" />
     <arg name="INPUT_CLOUD" value="/none" />
+    <arg name="INPUT_CANDIDATES" value="/none" />
   </include>
 
   <node name="label_image_decomposer1"


### PR DESCRIPTION
Because we changed the strategy to handle the unknown (newly passed)
objects.