### PR TITLE
reset gripper rotation after lifting object

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
@@ -639,6 +639,12 @@
       (send *ri* :angle-vector-raw (send *baxter* :angle-vector)
             3000 (send *ri* :get-arm-controller arm) 0)
       (send *ri* :wait-interpolation)
+      (let (av (end-pos (send (send *baxter* arm :end-coords :copy-worldcoords) :worldpos)))
+        (setq av (send *baxter* arm :inverse-kinematics (make-coords :pos end-pos :rpy #f(0 0 0))))
+        (if av
+            (progn
+              (send *ri* :angle-vector-raw av 2000 (send *ri* :get-arm-controller arm) 0)
+              (send *ri* :wait-interpolation))))
       (unix::sleep 1)  ;; wait for arm to follow
       (setq graspingp (send *ri* :graspingp arm :suction))
       (ros::ros-info "[:try-to-suction-object-with-gripper-v6] arm:~a graspingp: ~a" arm graspingp)
@@ -719,6 +725,12 @@
             :fast (send *ri* :get-arm-controller arm) 0 :scale 3.0)
       (send *ri* :wait-interpolation)
       (send *baxter* :angle-vector (send *ri* :state :potentio-vector :wait-until-update t))
+      (let (av (end-pos (send (send *baxter* arm :end-coords :copy-worldcoords) :worldpos)))
+        (setq av (send *baxter* arm :inverse-kinematics (make-coords :pos end-pos :rpy #f(0 0 0))))
+        (if av
+            (progn
+              (send *ri* :angle-vector-raw av 2000 (send *ri* :get-arm-controller arm) 0)
+              (send *ri* :wait-interpolation))))
       (setq graspingp (send *ri* :graspingp arm :pinch))
       (ros::ros-info "[:try-to-pinch-object] arm:~a graspingp: ~a" arm graspingp)
       graspingp))


### PR DESCRIPTION
pinchしたあとに物体を持ち上げると、グリッパのz軸周りの角度がおかしいままなことがあるので、物体を持ち上げたあとにリセットするようにしました。