### PR TITLE
Don't extend prismatic joint in :stop-grasp

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
@@ -389,8 +389,6 @@
                (when (> (aref finger-av 0) 45)
                  ;; if cylindrical and spherical grasp, move other gripper joints
                  (pushback (send robot :angle-vector) avs)
-                 (send robot l/r :gripper-x :joint-angle 120)
-                 (pushback (send robot :angle-vector) avs)
                  (send robot l/r :gripper-p :joint-angle 0)
                  (pushback (send robot :angle-vector) avs)
                  (send robot l/r :gripper-x :joint-angle 0)


### PR DESCRIPTION
In order to avoid collision to other objects in `return-object` or cardboard boxes in `place-object`