### PR TITLE
Publish nan value when unstable by EkEwIDriver

### DIFF
--- a/jsk_arc2017_common/node_scripts/ekew_i_driver.py
+++ b/jsk_arc2017_common/node_scripts/ekew_i_driver.py
@@ -46,7 +46,7 @@ class EkEwIDriver(object):
             return
 
         # get raw scale value without checking the mode of the scale
-        weight_raw = -1  # unknown
+        weight_raw = float('nan')  # unknown
         unit = data[12:15]
         if unit != '  g':
             rospy.logerr('Unsupported unit: %s', unit)
@@ -59,7 +59,7 @@ class EkEwIDriver(object):
 
         # get scale value with checking the mode of the scale
         header = data[:2]
-        weight = -1  # unknown
+        weight = float('nan')  # unknown
         if header == 'ST':
             # scale mode
             unit = data[12:15]

--- a/jsk_arc2017_common/node_scripts/weight_candidates_refiner.py
+++ b/jsk_arc2017_common/node_scripts/weight_candidates_refiner.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import math
+
 import jsk_arc2017_common
 from jsk_arc2017_common.msg import WeightStamped
 from jsk_recognition_msgs.msg import Label
@@ -73,7 +75,7 @@ class WeightCanditatesRefiner(object):
 
         assert len(weight_msgs) == len(self.prev_weight_values)
         weight_values = [w.weight.value for w in weight_msgs]
-        if any(w < 0 for w in weight_values):
+        if any(math.isnan(w) for w in weight_values):
             return  # unstable, scale over, or something
         self.prev_weight_values = weight_values
 

--- a/jsk_arc2017_common/node_scripts/weight_candidates_refiner.py
+++ b/jsk_arc2017_common/node_scripts/weight_candidates_refiner.py
@@ -76,6 +76,8 @@ class WeightCanditatesRefiner(object):
         assert len(weight_msgs) == len(self.prev_weight_values)
         weight_values = [w.weight.value for w in weight_msgs]
         if any(math.isnan(w) for w in weight_values):
+            rospy.logwarn_throttle(
+                10, 'NaN values are included in scale output, so skipping.')
             return  # unstable, scale over, or something
         self.prev_weight_values = weight_values
 


### PR DESCRIPTION
Close https://github.com/start-jsk/jsk_apc/issues/2529

-1 cannot represent unstable state of the scale, because the scale can output minus values.