### PR TITLE
Remove run_depend on baxter_sim_hardware to fix error on build.ros.org

### DIFF
--- a/jsk_2015_05_baxter_apc/package.xml
+++ b/jsk_2015_05_baxter_apc/package.xml
@@ -27,7 +27,11 @@
   <build_depend>xacro</build_depend>
 
   <run_depend>baxter_gazebo</run_depend>
+  <!--
+  FIXME: Can't be installed on build.ros.org.
+  https://github.com/start-jsk/jsk_apc/issues/2069
   <run_depend>baxter_sim_hardware</run_depend>
+  -->
   <run_depend>baxtereus</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>geometry_msgs</run_depend>


### PR DESCRIPTION
```
CMake Error at
/opt/ros/indigo/share/baxter_sim_hardware/cmake/baxter_sim_hardwareConfig.cmake:141
(message):
Project 'jsk_2015_05_baxter_apc' tried to find library
'baxter_sim_hardware'.  The library is neither a target nor
built/installed
properly.  Did you compile project 'baxter_sim_hardware'? Did you
find_package() it before the subdirectory containing its code is
included?
Call Stack (most recent call first):
CMakeLists.txt:21 (find_package)
CMakeLists.txt:97 (select_catkin_dependencies)
```