### PR TITLE
Re-calibrate left finger yaw joint

### DIFF
--- a/jsk_arc2017_baxter/robots/left_gripper_v6/dxl_controllers.yaml
+++ b/jsk_arc2017_baxter/robots/left_gripper_v6/dxl_controllers.yaml
@@ -35,7 +35,7 @@ finger_yaw_joint_controller:
     type: JointPositionController
   joint_name: left_gripper_finger_yaw_joint_motor
   joint_speed: 5.5
-  joint_torque_limit: 0.15
+  joint_torque_limit: 0.2
   motor:
     id: 2
     init: 650


### PR DESCRIPTION
More torque is needed to rotate yaw joint in new left finger