### PR TITLE
[jsk_arc2017_baxter] ungrasp condition in :wait-interpolation-until

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
@@ -501,6 +501,16 @@
                   t)
                 nil))
           conds))
+      (when (member :ungrasp args)
+        (ros::ros-info "[:wait-interpolation-until] Prepare for ungrasp")
+        (pushback
+          #'(lambda ()
+              (if (not (send self :graspingp arm))
+                (progn
+                  (ros::ros-info "[:wait-interpolation-until] Detected ungrasping")
+                  t)
+                nil))
+          conds))
       (when (member :finger-flexion args)
         (ros::ros-info "[:wait-interpolation-until] Prepare for finger flexion")
         (pushback


### PR DESCRIPTION
Baxter moves while succeeding in grasping, and stops to move when grasp failure is detected.
I use this in my experiment: https://github.com/mmurooka/euslib/blob/murooka-branch/demo/murooka/wholebody_manipulation_planner/demo_robot_carry_object/euslisp/demo-baxter-carry-block.l#L161.
If this is useful for APC, please use. otherwise, please close.
