### PR TITLE
Tune spin-off motions in stow

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
@@ -442,11 +442,12 @@
                         (arm2str arm) (underscore-to-space target-obj-)))
           (ros::ros-error "[main] arm ~a: dropped object" arm)
           (send *ri* :stop-grasp arm)
+          (when (eq grasp-style- :pinch)
+            (send *ri* :stop-grasp arm :pinch)
+            (send *baxter* :rotate-gripper arm 90 :relative nil))
           ;; we assume object is dropped, but it can be just a mis-detection of grasp
           (send self :spin-off-by-wrist arm :times 3)
           (send *ri* :wait-interpolation)
-          (if (eq grasp-style- :pinch)
-            (send *ri* :stop-grasp arm :pinch))
           (send self :add-postponed-object arm target-obj- target-bin-))
         (progn
           (ros::ros-info-green "[main] arm ~a: place object ~a in cardboard ~a" arm target-obj- target-cardboard-)

--- a/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
@@ -342,8 +342,12 @@
                         (arm2str arm) (underscore-to-space target-obj-)))
           (ros::ros-error "[main] arm ~a: dropped object" arm)
           (send *ri* :stop-grasp arm)
-          (if (eq grasp-style- :pinch)
-            (send *ri* :stop-grasp arm :pinch))
+          (when (eq grasp-style- :pinch)
+            (send *ri* :stop-grasp arm :pinch)
+            (send *baxter* :rotate-gripper arm 90 :relative nil))
+          ;; we assume object is dropped, but it can be just a mis-detection of grasp
+          (send self :spin-off-by-wrist arm :times 3)
+          (send *ri* :wait-interpolation)
           (send self :add-postponed-object arm target-obj- :tote))
         (progn
           (send self :update-json target-obj- :src :tote :dst (cons :bin target-bin-))

--- a/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
@@ -297,7 +297,7 @@
     (when (eq grasp-style- :pinch)
       (send *ri* :stop-grasp arm :pinch)
       (send *baxter* :rotate-gripper arm 90 :relative nil))
-    (send self :spin-off-by-wrist arm :times 5)
+    (send self :spin-off-by-wrist arm :times 3)
     (send *ri* :wait-interpolation)
     (ros::ros-info "[main] ~a, return object in tote" arm)
     (send *ri* :angle-vector-raw
@@ -370,7 +370,7 @@
           (when (eq grasp-style- :pinch)
             (send *ri* :stop-grasp arm :pinch)
             (send *baxter* :rotate-gripper arm 90 :relative nil)) ;; release object
-          (send self :spin-off-by-wrist arm :times 10)
+          (send self :spin-off-by-wrist arm :times 5)
           (send *ri* :wait-interpolation)
           (if (eq grasp-style- :suction)
             (send *ri* :angle-vector-raw

--- a/jsk_arc2017_baxter/launch/setup/setup_for_stow.launch
+++ b/jsk_arc2017_baxter/launch/setup/setup_for_stow.launch
@@ -3,6 +3,9 @@
   <arg name="stereo" default="true" />
   <arg name="load_driver" default="true" />
 
+  <!-- get machine tag -->
+  <include file="$(find jsk_arc2017_baxter)/launch/setup/include/baxter.machine" />
+
   <!-- hand mounted camera -->
   <group if="$(arg stereo)">
     <include file="$(find jsk_arc2017_baxter)/launch/setup/include/stereo_astra_hand.launch">


### PR DESCRIPTION
Depends on #2574 
- Apply https://github.com/start-jsk/jsk_apc/pull/2556/commits/2079f39c7492bea5943510edb20a871d667884fc in #2556 to stow task
- Fix release motion of pinch in `dropped`
  - This is never happened now. I just care about extendability.