### PR TITLE
Use master branch of jsk_common

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -1,7 +1,7 @@
 - git:
     local-name: jsk-ros-pkg/jsk_common
     uri: https://github.com/jsk-ros-pkg/jsk_common.git
-    version: jsk_apc
+    version: master
 - git:
     local-name: jsk-ros-pkg/jsk_recognition
     uri: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Now all programs used at ARC2017 are merged to jsk-ros-pkg/jsk_common.