### PR TITLE
Update docker config for start-jsk/jsk_apc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,5 +22,5 @@ RUN cd ~ && \
     wstool merge start-jsk/jsk_apc/.travis.rosinstall && \
     wstool up -j 2
 RUN rosdep update
-RUN rosdep install -r -y -i --from-path /opt/ros/indigo/share ~/src
+RUN rosdep install -r -y -i --from-paths /opt/ros/indigo/share ~/src
 RUN rm -rf ~/src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,5 +22,5 @@ RUN cd ~ && \
     wstool merge start-jsk/jsk_apc/.travis.rosinstall && \
     wstool up -j 2
 RUN rosdep update
-RUN rosdep install --from-path ~/src -r -y -i
+RUN rosdep install -r -y -i --from-path /opt/ros/indigo/share ~/src
 RUN rm -rf ~/src

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-sudo docker build -t jsk-apc-indigo .
-(echo -e "FROM jsk-apc-indigo\nRUN apt-get update\nRUN apt-get -y upgrade\nEXPOSE 22" | sudo docker build -t jsk-apc-indigo -)


### PR DESCRIPTION
It takes time to install dependencies on Jenkins using rosdep, without `--from-paths /opt/ros/indigo/share`.