### PR TITLE
Fix missing include files

### DIFF
--- a/jsk_2016_01_baxter_apc/CMakeLists.txt
+++ b/jsk_2016_01_baxter_apc/CMakeLists.txt
@@ -127,6 +127,7 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(include
+  ${catkin_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
 )
 

--- a/jsk_arc2017_baxter/CMakeLists.txt
+++ b/jsk_arc2017_baxter/CMakeLists.txt
@@ -81,6 +81,7 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(include
+  ${catkin_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
I got `No such file or directory "ros/ros.h"`.