### PR TITLE
version up rosserial in fc.rosintall

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -78,4 +78,4 @@
 - git:
     local-name: ros-drivers/rosserial
     uri: https://github.com/ros-drivers/rosserial
-    version: 0.7.4
+    version: 0.7.6


### PR DESCRIPTION
ROBOTIC MATERIALS社のparallel gripper kitに
https://github.com/knorth55/FA-I-sensor/blob/add-proximity-grippers/force_proximity_ros/src/proximity_grippers/proximity_grippers.ino
を書き込んで使おうとしたのですが、コンパイル時に
https://github.com/ros-drivers/rosserial/issues/259
のようなエラーが出ました。
上のissueの通り、rosserialのバージョンを0.7.6にしたらコンパイルが通るようになり、値が読めるようになりました。