### PR TITLE
fix typo in doc

### DIFF
--- a/doc/jsk_arc2017_baxter/state_machine.rst
+++ b/doc/jsk_arc2017_baxter/state_machine.rst
@@ -1,7 +1,7 @@
 State Machine
 =============
 
-Task states are controllerd by ``smach``.
+Task states are controlled by ``smach``.
 You can check state machines by ``smach_viewer``.
 
 Pick Task
@@ -23,5 +23,3 @@ Stow Task
 
   # Run stow task with smach_viewer
   baxter@sheeta $ roslaunch jsk_arc2017_baxter stow.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_stow_task smach_viewer:=true
-
-


### PR DESCRIPTION
`controllerd`
->
`controlled`