### PR TITLE
Fix *ri* :speak method according to the upstream change

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/baxter-interface.l
@@ -626,11 +626,6 @@
                (send self :get-proximity l/r :right :raw t))
       ;; TODO: decide proper threshold 100 -> ???
       (setq proximity-threshold- 100)))
-  (:speak
-    (msg &key (wait nil))
-    (assert (stringp msg) (format nil "Invalid msg, though string is expected: ~a" msg))
-    (speak-en msg :wait wait)
-    )
   )
 
 (defclass jsk_arc2017_baxter::baxter-moveit-environment


### PR DESCRIPTION
`:speak` method is added to the robot-interface which is the super class of baxter-interface.