### PR TITLE
Fixes for demo on 2018-01-19

### DIFF
--- a/jsk_arc2017_common/data/models/.gitignore
+++ b/jsk_arc2017_common/data/models/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!fcn32s.npz

--- a/jsk_arc2017_common/node_scripts/candidates_publisher.py
+++ b/jsk_arc2017_common/node_scripts/candidates_publisher.py
@@ -20,8 +20,8 @@ class CandidatesPublisher(ConnectionBasedTransport):
             '~output/candidates', LabelArray, queue_size=1)
         self.srv = dynamic_reconfigure.server.Server(
             CandidatesPublisherConfig, self._config_cb)
-        self.label_names = rospy.get_param('~json_dir', None)
-        self.json_dir = None
+        self.label_names = rospy.get_param('~label_names')
+        self.json_dir = rospy.get_param('~json_dir', None)
         hz = rospy.get_param('~hz', 10.0)
         self.timer = rospy.Timer(rospy.Duration(1.0 / hz), self._timer_cb)
 

--- a/jsk_arc2017_common/node_scripts/candidates_publisher.py
+++ b/jsk_arc2017_common/node_scripts/candidates_publisher.py
@@ -21,7 +21,7 @@ class CandidatesPublisher(ConnectionBasedTransport):
         self.srv = dynamic_reconfigure.server.Server(
             CandidatesPublisherConfig, self._config_cb)
         self.label_names = rospy.get_param('~label_names')
-        self.json_dir = rospy.get_param('~json_dir')
+        self.json_dir = None
         hz = rospy.get_param('~hz', 10.0)
         self.timer = rospy.Timer(rospy.Duration(1.0 / hz), self._timer_cb)
 
@@ -39,6 +39,10 @@ class CandidatesPublisher(ConnectionBasedTransport):
         self.json_dir = msg.data
 
     def _timer_cb(self, event):
+        if self.json_dir is None:
+            rospy.logwarn_throttle(10, 'Input json_dir is not set.')
+            return
+
         if not osp.isdir(self.json_dir):
             rospy.logfatal_throttle(
                 10, 'Input json_dir is not directory: %s' % self.json_dir)

--- a/jsk_arc2017_common/node_scripts/candidates_publisher.py
+++ b/jsk_arc2017_common/node_scripts/candidates_publisher.py
@@ -20,7 +20,7 @@ class CandidatesPublisher(ConnectionBasedTransport):
             '~output/candidates', LabelArray, queue_size=1)
         self.srv = dynamic_reconfigure.server.Server(
             CandidatesPublisherConfig, self._config_cb)
-        self.label_names = rospy.get_param('~label_names')
+        self.label_names = rospy.get_param('~json_dir', None)
         self.json_dir = None
         hz = rospy.get_param('~hz', 10.0)
         self.timer = rospy.Timer(rospy.Duration(1.0 / hz), self._timer_cb)

--- a/jsk_arc2017_common/python/jsk_arc2017_common/utils.py
+++ b/jsk_arc2017_common/python/jsk_arc2017_common/utils.py
@@ -261,6 +261,8 @@ def visualize_item_location(filename, order_file=None):
     imgs_top.append(img_container)
     # bin
     for bin_ in sorted(item_location['bins'], reverse=True):  # C, B, A
+        if not bin_['contents']:
+            continue  # skip empty bin
         img_container = visualize_container(
             bin_['bin_id'], bin_['contents'], orders=orders,
             container_file=osp.join(PKG_DIR, 'data/objects/bin/top.jpg'),


### PR DESCRIPTION
- Don't ignore fcn32s.npz to remove it by git clean

for git clean

- Skip empty bin while visualizing JSON

To make visualization better.

- Fix unreasonable ~json_dir param to candidates_publisher

a bug introduced by https://github.com/start-jsk/jsk_apc/pull/2618