### PR TITLE
use smaller collision head

### DIFF
--- a/jsk_2016_01_baxter_apc/robots/baxter_simple.urdf
+++ b/jsk_2016_01_baxter_apc/robots/baxter_simple.urdf
@@ -175,7 +175,7 @@
     <collision>
       <origin rpy="0 0 0.0" xyz="-0.07 -0.04 0.0"/>
       <geometry>
-        <sphere radius="0.22"/>
+        <sphere radius="0.1"/>
       </geometry>
     </collision>
     <inertial>
@@ -197,7 +197,7 @@
     <collision>
       <origin rpy="0 0 0" xyz="-0.07 0.04 0.00"/>
       <geometry>
-        <sphere radius="0.22"/>
+        <sphere radius="0.1"/>
       </geometry>
     </collision>
     <inertial>


### PR DESCRIPTION
collision head was modified to original big one in https://github.com/start-jsk/jsk_apc/pull/2311
it was as small as this PR in ARC2017 (https://github.com/knorth55/baxter_common/commit/a722703d2ab67df252e0a98aac32f91bffc845f5)