### PR TITLE
Fix Kinetic build

### DIFF
--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,23 +1,17 @@
+# not released yet in kinetic
+- git:
+    local-name: baxter_simulator
+    uri: https://github.com/RethinkRobotics/baxter_simulator.git
+    version: kinetic-devel
+# 2.1.3 is not released yet in kinetic
+- tar:
+    local-name: jsk_visualization/jsk_interactive_marker
+    uri: https://github.com/tork-a/jsk_visualization-release/archive/release/indigo/jsk_interactive_marker/2.1.3-0.tar.gz
+    version: jsk_visualization-release-release-indigo-jsk_interactive_marker-2.1.3-0
 - tar:
     local-name: baxter_examples
     uri: https://github.com/RethinkRobotics-release/baxter_examples-release/archive/release/indigo/baxter_examples/1.2.0-0.tar.gz
     version: baxter_examples-release-release-indigo-baxter_examples-1.2.0-0
-- tar:
-    local-name: baxter_simulator/baxter_gazebo
-    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_gazebo/1.2.12-0.tar.gz
-    version: baxter_simulator-release-release-indigo-baxter_gazebo-1.2.12-0
-- tar:
-    local-name: baxter_simulator/baxter_sim_controllers
-    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_sim_controllers/1.2.12-0.tar.gz
-    version: baxter_simulator-release-release-indigo-baxter_sim_controllers-1.2.12-0
-- tar:
-    local-name: baxter_simulator/baxter_sim_hardware
-    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_sim_hardware/1.2.12-0.tar.gz
-    version: baxter_simulator-release-release-indigo-baxter_sim_hardware-1.2.12-0
-- tar:
-    local-name: baxter_simulator/baxter_sim_io
-    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_sim_io/1.2.12-0.tar.gz
-    version: baxter_simulator-release-release-indigo-baxter_sim_io-1.2.12-0
 - tar:
     local-name: baxter_tools
     uri: https://github.com/RethinkRobotics-release/baxter_tools-release/archive/release/indigo/baxter_tools/1.2.0-0.tar.gz
@@ -58,7 +52,3 @@
     local-name: baxter_interface
     uri: https://github.com/RethinkRobotics-release/baxter_interface-release/archive/release/indigo/baxter_interface/1.2.0-0.tar.gz
     version: baxter_interface-release-release-indigo-baxter_interface-1.2.0-0
-- tar:
-    local-name: baxter_simulator/baxter_sim_kinematics
-    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_sim_kinematics/1.2.12-0.tar.gz
-    version: baxter_simulator-release-release-indigo-baxter_sim_kinematics-1.2.12-0

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,0 +1,64 @@
+- tar:
+    local-name: baxter_examples
+    uri: https://github.com/RethinkRobotics-release/baxter_examples-release/archive/release/indigo/baxter_examples/1.2.0-0.tar.gz
+    version: baxter_examples-release-release-indigo-baxter_examples-1.2.0-0
+- tar:
+    local-name: baxter_simulator/baxter_gazebo
+    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_gazebo/1.2.12-0.tar.gz
+    version: baxter_simulator-release-release-indigo-baxter_gazebo-1.2.12-0
+- tar:
+    local-name: baxter_simulator/baxter_sim_controllers
+    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_sim_controllers/1.2.12-0.tar.gz
+    version: baxter_simulator-release-release-indigo-baxter_sim_controllers-1.2.12-0
+- tar:
+    local-name: baxter_simulator/baxter_sim_hardware
+    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_sim_hardware/1.2.12-0.tar.gz
+    version: baxter_simulator-release-release-indigo-baxter_sim_hardware-1.2.12-0
+- tar:
+    local-name: baxter_simulator/baxter_sim_io
+    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_sim_io/1.2.12-0.tar.gz
+    version: baxter_simulator-release-release-indigo-baxter_sim_io-1.2.12-0
+- tar:
+    local-name: baxter_tools
+    uri: https://github.com/RethinkRobotics-release/baxter_tools-release/archive/release/indigo/baxter_tools/1.2.0-0.tar.gz
+    version: baxter_tools-release-release-indigo-baxter_tools-1.2.0-0
+- tar:
+    local-name: jsk_3rdparty/rostwitter
+    uri: https://github.com/tork-a/jsk_3rdparty-release/archive/release/indigo/rostwitter/2.1.10-0.tar.gz
+    version: jsk_3rdparty-release-release-indigo-rostwitter-2.1.10-0
+- tar:
+    local-name: jsk_demos/jsk_demo_common
+    uri: https://github.com/tork-a/jsk_demos-release/archive/release/indigo/jsk_demo_common/0.0.4-0.tar.gz
+    version: jsk_demos-release-release-indigo-jsk_demo_common-0.0.4-0
+- tar:
+    local-name: jsk_demos/jsk_maps
+    uri: https://github.com/tork-a/jsk_demos-release/archive/release/indigo/jsk_maps/0.0.4-0.tar.gz
+    version: jsk_demos-release-release-indigo-jsk_maps-0.0.4-0
+- tar:
+    local-name: jsk_robot/baxtereus
+    uri: https://github.com/tork-a/jsk_robot-release/archive/release/indigo/baxtereus/1.1.0-1.tar.gz
+    version: jsk_robot-release-release-indigo-baxtereus-1.1.0-1
+- tar:
+    local-name: jsk_robot/jsk_baxter_startup
+    uri: https://github.com/tork-a/jsk_robot-release/archive/release/indigo/jsk_baxter_startup/1.1.0-1.tar.gz
+    version: jsk_robot-release-release-indigo-jsk_baxter_startup-1.1.0-1
+- tar:
+    local-name: jsk_roseus/roseus_mongo
+    uri: https://github.com/tork-a/jsk_roseus-release/archive/release/indigo/roseus_mongo/1.6.3-0.tar.gz
+    version: jsk_roseus-release-release-indigo-roseus_mongo-1.6.3-0
+- tar:
+    local-name: moveit_robots/baxter_moveit_config
+    uri: https://github.com/ros-gbp/moveit_robots-release/archive/release/indigo/baxter_moveit_config/1.0.7-0.tar.gz
+    version: moveit_robots-release-release-indigo-baxter_moveit_config-1.0.7-0
+- tar:
+    local-name: pr2_gripper_sensor/pr2_gripper_sensor_msgs
+    uri: https://github.com/pr2-gbp/pr2_gripper_sensor-release/archive/release/indigo/pr2_gripper_sensor_msgs/1.0.9-0.tar.gz
+    version: pr2_gripper_sensor-release-release-indigo-pr2_gripper_sensor_msgs-1.0.9-0
+- tar:
+    local-name: baxter_interface
+    uri: https://github.com/RethinkRobotics-release/baxter_interface-release/archive/release/indigo/baxter_interface/1.2.0-0.tar.gz
+    version: baxter_interface-release-release-indigo-baxter_interface-1.2.0-0
+- tar:
+    local-name: baxter_simulator/baxter_sim_kinematics
+    uri: https://github.com/RethinkRobotics-release/baxter_simulator-release/archive/release/indigo/baxter_sim_kinematics/1.2.12-0.tar.gz
+    version: baxter_simulator-release-release-indigo-baxter_sim_kinematics-1.2.12-0

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,10 @@ env:
     - USE_TRAVIS=true
   matrix:
     - ROS_DISTRO=indigo
-    - ROS_DISTRO=kinetic ROSDEP_YET_ADDITIONAL_OPTIONS="--skip-keys=jsk_demo_common --skip-keys=roseus_mongo --skip-keys=jsk_baxter_startup --skip-keys=baxtereus --skip-keys=baxter_gazebo --skip-keys=baxter_sim_io --skip-keys=baxter_sim_controllers"
+    - ROS_DISTRO=kinetic
 
 script:
   - export DOCKER_IMAGE="wkentaro/jsk_apc:$ROS_DISTRO"
-  - export ROSDEP_ADDITIONAL_OPTIONS="$ROSDEP_ADDITIONAL_OPTIONS $ROSDEP_YET_ADDITIONAL_OPTIONS"
   # build & test ROS packages
   - source .travis/travis.sh
   # build doc

--- a/jsk_2016_01_baxter_apc/euslisp/lib/baxter-interface.l
+++ b/jsk_2016_01_baxter_apc/euslisp/lib/baxter-interface.l
@@ -5,7 +5,10 @@
 (require "package://jsk_2016_01_baxter_apc/euslisp/lib/baxter.l")
 (require "package://jsk_2016_01_baxter_apc/euslisp/lib/util.l")
 
-(ros::load-ros-manifest "jsk_2016_01_baxter_apc")
+(ros::load-ros-manifest "control_msgs")
+(ros::load-ros-manifest "jsk_2015_05_baxter_apc")
+(ros::load-ros-manifest "jsk_recognition_msgs")
+(ros::load-ros-manifest "std_msgs")
 
 (unless (find-package "JSK_2016_01_BAXTER_APC")
   (make-package "JSK_2016_01_BAXTER_APC"))

--- a/jsk_2016_01_baxter_apc/euslisp/lib/util.l
+++ b/jsk_2016_01_baxter_apc/euslisp/lib/util.l
@@ -79,22 +79,3 @@
 (defun ros::ros-info-cyan (fmt &rest args)
   (ros::ros-info "~C[3~Cm~A~C[0m" #x1b 54 (apply #'format nil fmt args) #x1b)
   )
-
-
-;; ------------------------------------------------------------------------------------------------
-;; Json Utils
-;; ------------------------------------------------------------------------------------------------
-
-(require :json-decode "package://roseus_mongo/euslisp/json/json-decode.l")
-
-(defun read-file-into-string (filename)
-  (with-open-file (f filename :direction :input)
-    (let (buf (str-list nil))
-      (while (setq buf (read-line f nil))
-             (setq str-list (append str-list (list (format nil buf)))))
-      (reduce #'(lambda (x y) (concatenate string x y)) str-list))))
-
-(defun read-json-into-string (filename)
-  (if (substringp "package://" filename)
-    (setq filename (ros::resolve-ros-path filename)))
-  (json::parse-from-string (read-file-into-string filename)))

--- a/jsk_2016_01_baxter_apc/package.xml
+++ b/jsk_2016_01_baxter_apc/package.xml
@@ -48,7 +48,6 @@
   <run_depend>jsk_interactive_marker</run_depend>
   <run_depend>jsk_recognition_msgs</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>roseus_mongo</run_depend>
   <run_depend>rosserial_python</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>jsk_data</run_depend>

--- a/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h
+++ b/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h
@@ -4,6 +4,9 @@
 #ifndef JSK_ARC2017_BAXTER_TENDON_TRANSMISSION_LOADER_H
 #define JSK_ARC2017_BAXTER_TENDON_TRANSMISSION_LOADER_H
 
+// ROS
+#include <ros/common.h>
+
 // TinyXML
 #include <tinyxml.h>
 
@@ -16,7 +19,10 @@ namespace jsk_arc2017_baxter
 class TendonTransmissionLoader : public transmission_interface::TransmissionLoader
 {
 public:
-  transmission_interface::TransmissionSharedPtr load(const transmission_interface::TransmissionInfo& transmission_info);
+  #if ROS_VERSION_MINIMUM(1, 12, 0) // ROS Kinetic and above
+    typedef transmission_interface::TransmissionSharedPtr TransmissionPtr;
+  #endif
+  TransmissionPtr load(const transmission_interface::TransmissionInfo& transmission_info);
 
 private:
   static bool getJointConfig(const transmission_interface::TransmissionInfo& transmission_info,

--- a/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h
+++ b/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h
@@ -16,7 +16,7 @@ namespace jsk_arc2017_baxter
 class TendonTransmissionLoader : public transmission_interface::TransmissionLoader
 {
 public:
-  TransmissionPtr load(const transmission_interface::TransmissionInfo& transmission_info);
+  transmission_interface::TransmissionSharedPtr load(const transmission_interface::TransmissionInfo& transmission_info);
 
 private:
   static bool getJointConfig(const transmission_interface::TransmissionInfo& transmission_info,

--- a/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp
+++ b/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp
@@ -17,11 +17,11 @@
 
 namespace jsk_arc2017_baxter
 {
-TendonTransmissionLoader::TransmissionPtr
+transmission_interface::TransmissionSharedPtr
 TendonTransmissionLoader::load(const transmission_interface::TransmissionInfo& transmission_info)
 {
   // Transmission should contain only one actuator
-  if (!checkActuatorDimension(transmission_info, 1)) {return TransmissionPtr();}
+  if (!checkActuatorDimension(transmission_info, 1)) {return transmission_interface::TransmissionSharedPtr();}
 
   // Get joint configuration
   std::vector<double> jnt_reduction;
@@ -30,12 +30,12 @@ TendonTransmissionLoader::load(const transmission_interface::TransmissionInfo& t
                                             jnt_reduction,
                                             jnt_limit);
 
-  if (!jnt_config_ok) {return TransmissionPtr();}
+  if (!jnt_config_ok) {return transmission_interface::TransmissionSharedPtr();}
 
   // Transmission instance
   try
   {
-    TransmissionPtr transmission(new TendonTransmission(jnt_reduction, jnt_limit));
+    transmission_interface::TransmissionSharedPtr transmission(new TendonTransmission(jnt_reduction, jnt_limit));
     return transmission;
   }
   catch(const transmission_interface::TransmissionInterfaceException& ex)
@@ -43,7 +43,7 @@ TendonTransmissionLoader::load(const transmission_interface::TransmissionInfo& t
     using hardware_interface::internal::demangledTypeName;
     ROS_ERROR_STREAM_NAMED("parser", "Failed to construct transmission '" << transmission_info.name_ << "' of type '" <<
                            demangledTypeName<TendonTransmission>()<< "'. " << ex.what());
-    return TransmissionPtr();
+    return transmission_interface::TransmissionSharedPtr();
   }
 }
 

--- a/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp
+++ b/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp
@@ -17,11 +17,11 @@
 
 namespace jsk_arc2017_baxter
 {
-transmission_interface::TransmissionSharedPtr
+TendonTransmissionLoader::TransmissionPtr
 TendonTransmissionLoader::load(const transmission_interface::TransmissionInfo& transmission_info)
 {
   // Transmission should contain only one actuator
-  if (!checkActuatorDimension(transmission_info, 1)) {return transmission_interface::TransmissionSharedPtr();}
+  if (!checkActuatorDimension(transmission_info, 1)) {return TransmissionPtr();}
 
   // Get joint configuration
   std::vector<double> jnt_reduction;
@@ -30,12 +30,12 @@ TendonTransmissionLoader::load(const transmission_interface::TransmissionInfo& t
                                             jnt_reduction,
                                             jnt_limit);
 
-  if (!jnt_config_ok) {return transmission_interface::TransmissionSharedPtr();}
+  if (!jnt_config_ok) {return TransmissionPtr();}
 
   // Transmission instance
   try
   {
-    transmission_interface::TransmissionSharedPtr transmission(new TendonTransmission(jnt_reduction, jnt_limit));
+    TransmissionPtr transmission(new TendonTransmission(jnt_reduction, jnt_limit));
     return transmission;
   }
   catch(const transmission_interface::TransmissionInterfaceException& ex)
@@ -43,7 +43,7 @@ TendonTransmissionLoader::load(const transmission_interface::TransmissionInfo& t
     using hardware_interface::internal::demangledTypeName;
     ROS_ERROR_STREAM_NAMED("parser", "Failed to construct transmission '" << transmission_info.name_ << "' of type '" <<
                            demangledTypeName<TendonTransmission>()<< "'. " << ex.what());
-    return transmission_interface::TransmissionSharedPtr();
+    return TransmissionPtr();
   }
 }
 


### PR DESCRIPTION
Build failure on `jsk_arc2017_baxter` in Kinetic.
Because of this change in Kinetic. https://github.com/ros-controls/ros_control/pull/324
This change is quite huge :(.

Change is 
- `TransmissionPtr` -> `transmission_interface::TransmissionSharedPtr`

```cpp
Starting  >>> jsk_arc2017_baxter                                                                    
____________________________________________________________________________________________________
Errors     << jsk_arc2017_baxter:make /home/shingo/ros/kinetic/logs/jsk_arc2017_baxter/build.make.026.log
In file included from /home/shingo/ros/kinetic/src/start-jsk/jsk_apc/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp:16:0:
/home/shingo/ros/kinetic/src/start-jsk/jsk_apc/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h:19:3: error: ‘TransmissionPtr’ does not name a type
   TransmissionPtr load(const transmission_interface::TransmissionInfo& transmission_info);
   ^
/home/shingo/ros/kinetic/src/start-jsk/jsk_apc/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp:20:27: error: ‘TransmissionPtr’ in ‘class jsk_arc2017_baxter::TendonTransmissionLoader’ does not name a type
 TendonTransmissionLoader::TransmissionPtr
                           ^
In file included from /opt/ros/kinetic/include/class_loader/class_loader_core.hpp:46:0,
                 from /opt/ros/kinetic/include/class_loader/./class_loader.hpp:43,
                 from /opt/ros/kinetic/include/class_loader/class_loader.h:35,
                 from /opt/ros/kinetic/include/pluginlib/./class_list_macros.hpp:40,
                 from /opt/ros/kinetic/include/pluginlib/class_list_macros.h:35,
                 from /home/shingo/ros/kinetic/src/start-jsk/jsk_apc/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp:11:
/opt/ros/kinetic/include/class_loader/meta_object.hpp: In instantiation of ‘B* class_loader::class_loader_private::MetaObject<C, B>::create() const [with C = jsk_arc2017_baxter::TendonTransmissionLoader; B = transmission_interface::TransmissionLoader]’:
/home/shingo/ros/kinetic/src/start-jsk/jsk_apc/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp:119:1:   required from here
/opt/ros/kinetic/include/class_loader/meta_object.hpp:198:16: error: invalid new-expression of abstract class type ‘jsk_arc2017_baxter::TendonTransmissionLoader’
     return new C;
                ^
In file included from /home/shingo/ros/kinetic/src/start-jsk/jsk_apc/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp:16:0:
/home/shingo/ros/kinetic/src/start-jsk/jsk_apc/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h:16:7: note:   because the following virtual functions are pure within ‘jsk_arc2017_baxter::TendonTransmissionLoader’:
 class TendonTransmissionLoader : public transmission_interface::TransmissionLoader
       ^
In file included from /home/shingo/ros/kinetic/src/start-jsk/jsk_apc/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h:11:0,
                 from /home/shingo/ros/kinetic/src/start-jsk/jsk_apc/jsk_arc2017_baxter/src/tendon_transmission_loader.cpp:16:
/opt/ros/kinetic/include/transmission_interface/transmission_loader.h:70:33: note: 	virtual transmission_interface::TransmissionSharedPtr transmission_interface::TransmissionLoader::load(const transmission_interface::TransmissionInfo&)
   virtual TransmissionSharedPtr load(const TransmissionInfo& transmission_info) = 0;
                                 ^
make[2]: *** [CMakeFiles/jsk_arc2017_baxter_transmission_loader_plugins.dir/src/tendon_transmission_loader.cpp.o] エラー 1
make[1]: *** [CMakeFiles/jsk_arc2017_baxter_transmission_loader_plugins.dir/all] エラー 2
make: *** [all] エラー 2
cd /home/shingo/ros/kinetic/build/jsk_arc2017_baxter; catkin build --get-env jsk_arc2017_baxter | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
....................................................................................................
Failed     << jsk_arc2017_baxter:make                [ Exited with code 2 ]                         
Failed    <<< jsk_arc2017_baxter                     [ 2.2 seconds ]       
```


@pazeshun This PR is my debug fix for Kinetic build.
But we still use Baxter in Indigo, so there is no need to merge this now.
I want to find solution which we can build this with both indigo and kinetic.
One idea is to ask to backport the PR( https://github.com/ros-controls/ros_control/pull/32) into `indigo-devel`.


