### PR TITLE
Re-calibrate finger tendon winder

### DIFF
--- a/jsk_arc2017_baxter/robots/right_gripper_v6/dxl_controllers.yaml
+++ b/jsk_arc2017_baxter/robots/right_gripper_v6/dxl_controllers.yaml
@@ -52,6 +52,6 @@ finger_tendon_controller:
   ignored_errors: ['DXL_OVERLOAD_ERROR']
   motor:
     id: 3
-    init: 3140
-    min: 3140
-    max: 570
+    init: 3080
+    min: 3080
+    max: 510


### PR DESCRIPTION
Because the finger tendon pulley in right hand is chipped:
![dsc_1837](https://user-images.githubusercontent.com/14994939/40164779-6cc605d4-59f5-11e8-803f-ed6a10075318.JPG)
