### PR TITLE
Remove image_proc 1.12.20 from fc.rosinstall

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -69,9 +69,3 @@
     local-name: ros-drivers/rosserial
     uri: https://github.com/ros-drivers/rosserial
     version: 0.7.6
-# corrupting PR is merged in 1.12.21
-# https://github.com/ros-perception/image_pipeline/pull/299
-- tar:
-    local-name: image_pipeline/image_proc
-    uri: https://github.com/ros-gbp/image_pipeline-release/archive/release/indigo/image_proc/1.12.20-0.tar.gz
-    version: image_pipeline-release-release-indigo-image_proc-1.12.20-0

--- a/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h
+++ b/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h
@@ -19,9 +19,7 @@ namespace jsk_arc2017_baxter
 class TendonTransmissionLoader : public transmission_interface::TransmissionLoader
 {
 public:
-  #if ROS_VERSION_MINIMUM(1, 12, 0) // ROS Kinetic and above
-    typedef transmission_interface::TransmissionSharedPtr TransmissionPtr;
-  #endif
+  typedef transmission_interface::TransmissionSharedPtr TransmissionPtr;
   TransmissionPtr load(const transmission_interface::TransmissionInfo& transmission_info);
 
 private:


### PR DESCRIPTION
Now image_proc 1.12.23 is released.
http://repositories.ros.org/status_page/ros_indigo_default.html?q=image_proc