### PR TITLE
Remove jsk_visualization from fc.rosinstall

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -6,12 +6,6 @@
     local-name: jsk-ros-pkg/jsk_recognition
     uri: https://github.com/jsk-ros-pkg/jsk_recognition.git
     version: master
-# jsk_visualization needs below:
-# https://github.com/jsk-ros-pkg/jsk_visualization/pull/670
-- git:
-    local-name: jsk-ros-pkg/jsk_visualization
-    uri: https://github.com/jsk-ros-pkg/jsk_visualization.git
-    version: master
 - git:
     local-name: jsk-ros-pkg/jsk_robot
     uri: https://github.com/jsk-ros-pkg/jsk_robot.git

--- a/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h
+++ b/jsk_arc2017_baxter/include/jsk_arc2017_baxter/tendon_transmission_loader.h
@@ -19,9 +19,7 @@ namespace jsk_arc2017_baxter
 class TendonTransmissionLoader : public transmission_interface::TransmissionLoader
 {
 public:
-  #if ROS_VERSION_MINIMUM(1, 12, 0) // ROS Kinetic and above
-    typedef transmission_interface::TransmissionSharedPtr TransmissionPtr;
-  #endif
+  typedef transmission_interface::TransmissionSharedPtr TransmissionPtr;
   TransmissionPtr load(const transmission_interface::TransmissionInfo& transmission_info);
 
 private:


### PR DESCRIPTION
jsk_visualization 2.1.3 is released which includes the commit we need:
https://github.com/jsk-ros-pkg/jsk_visualization/commit/ceaa9333d14fd627c80671ccef76cf0302fc1d75 
http://repositories.ros.org/status_page/ros_indigo_default.html?q=jsk_visualization