### PR TITLE
Return recognized timestamp in :recognize-target-object

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
@@ -379,7 +379,7 @@
            (progn
              (sethash arm object-boxes- obj-box)
              (sethash arm object-coords- obj-coords)
-             (setq is-recognized t))
+             (setq is-recognized (send box-msg :header :stamp)))
            (progn
              (ros::ros-error "[:recognize-target-object] arm: ~a obj-box length ~a" arm (length obj-box))
              (ros::ros-error "[:recognize-target-object] arm: ~a obj-coords length ~a" arm (length obj-coords))


### PR DESCRIPTION
I need this to request the name of the subscribed bounding box
by using a service call to a image pipeline node which has a map from timestamp to object name.