### PR TITLE
Fix :recognize-object to return t or nil

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/pick-interface.l
@@ -143,7 +143,7 @@
                 (setq moving-object-p- t)
                 (send self :recognize-target-object arm :stamp (ros::time-now))))
             (incf recognition-count))))
-      is-recognized))
+      (not (null is-recognized))))
   (:return-from-recognize-object (arm)
     (send self :add-postponed-object arm target-obj- target-bin-)
     (setq start-picking-fail-count- 0)

--- a/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/stow-interface.l
@@ -99,7 +99,7 @@
                 (instance std_srvs::TriggerRequest :init))
               (send self :recognize-target-object arm :stamp (ros::time-now))))
           (incf recognition-count)))
-      is-recognized))
+      (not (null is-recognized))))
   (:return-from-recognize-object (arm)
     (send self :add-postponed-object arm target-obj- :tote)
     (setq start-picking-fail-count- 0)


### PR DESCRIPTION
#2648 makes `is-recognized` time stamp or nil, but `:recognize-object` should return t or nil for state machine.