### PR TITLE
Try docker image with latest apt pkgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - ROS_DISTRO=kinetic
 
 script:
-  - export DOCKER_IMAGE="wkentaro/jsk_apc:$ROS_DISTRO"
+  - export DOCKER_IMAGE="pazeshun/jsk_apc:$ROS_DISTRO"
   # build & test ROS packages
   - source .travis/travis.sh
   # build doc


### PR DESCRIPTION
This PR checks if new docker image solves travis failure.

I created a container from docker image `wkentaro/jsk_apc:<indigo/kinetic>`, executed `apt-get update && apt-get dist-upgrade` in that container, and committed that container to docker image `pazeshun/jsk_apc:<indigo/kinetic>`.

If travis test of this PR passes, we just need to update `wkentaro/jsk_apc:<indigo/kinetic>` manually to pass travis test from now.