### PR TITLE
Use docker image under jsk organization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - ROS_DISTRO=kinetic
 
 script:
-  - export DOCKER_IMAGE="wkentaro/jsk_apc:$ROS_DISTRO"
+  - export DOCKER_IMAGE="jskrobotics/jsk_apc:$ROS_DISTRO"
   # build & test ROS packages
   - source .travis/travis.sh
   # build doc
@@ -41,7 +41,7 @@ after_script:
   # trigger the build of the docker image
   # If the test fails, new docker image can be helpful,
   # so it should be triggered at both after_success and failure.
-  - curl -X POST https://registry.hub.docker.com/u/wkentaro/jsk_apc/trigger/3ed08cc3-12bf-4a63-85a7-8082180f3639/
+  - curl -X POST https://registry.hub.docker.com/u/jskrobotics/jsk_apc/trigger/c4af5c9a-cf54-45b1-8beb-ccba5a102a1f/
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ jsk\_apc
 [![Gitter](https://badges.gitter.im/start-jsk/jsk_apc.svg)](https://gitter.im/start-jsk/jsk_apc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Slack](https://img.shields.io/badge/slack-%23jsk__apc-e100e1.svg)](https://jsk-robotics.slack.com/messages/jsk_apc/)
 [![Documentation Status](https://readthedocs.org/projects/jsk-apc/badge/?version=latest)](http://jsk-apc.readthedocs.org/en/latest/?badge=latest)
-[![Docker Build Status](https://img.shields.io/docker/build/wkentaro/jsk_apc.svg)](https://hub.docker.com/r/wkentaro/jsk_apc)  
+[![Docker Build Status](https://img.shields.io/docker/build/jskrobotics/jsk_apc.svg)](https://hub.docker.com/r/jskrobotics/jsk_apc)
 **Forum** ([baxter](https://groups.google.com/a/jsk.imi.i.u-tokyo.ac.jp/forum/#!forum/baxter), [apc](https://groups.google.com/a/jsk.imi.i.u-tokyo.ac.jp/forum/#!forum/apc))
 
 


### PR DESCRIPTION
I created https://hub.docker.com/r/jskrobotics/jsk_apc/ and use this instead of wkentaro/jsk_apc in order to keep maintained by jsk lab.