### PR TITLE
[jsk_arc2017_common] Add script to install pick_re-experiment (experiment imitating ARC2017 pick competition)

### DIFF
--- a/doc/jsk_arc2017_baxter/arc2017_pick_trial.rst
+++ b/doc/jsk_arc2017_baxter/arc2017_pick_trial.rst
@@ -20,3 +20,22 @@ Pick task trial on real world for ARC2017 can be done on ``baxter@baxter-c1``.
   # Run task!
   baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter pick.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_pick_task
 
+With Environment Imitating ARC2017 Pick Competition
+---------------------------------------------------
+
+Preparation
+^^^^^^^^^^^
+
+.. code-block:: bash
+
+  baxter@baxter-c1 $ rosrun jsk_arc2017_common install_pick_re-experiment
+
+Execution
+^^^^^^^^^
+
+.. code-block:: bash
+
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter baxter.launch
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter setup_for_pick.launch
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter pick.launch json_dir:=$HOME/data/arc2017/system_inputs_jsons/pick_re-experiment/json
+

--- a/doc/jsk_arc2017_baxter/arc2017_pick_trial.rst
+++ b/doc/jsk_arc2017_baxter/arc2017_pick_trial.rst
@@ -1,7 +1,7 @@
 ARC2017 Pick Task Trial on Real World
 =====================================
 
-Pick task trial on real world for ARC2017 can be done on ``baxter@sheeta``.
+Pick task trial on real world for ARC2017 can be done on ``baxter@baxter-c1``.
 
 - Prepare json.
 - Set objects in Shelf.
@@ -9,14 +9,14 @@ Pick task trial on real world for ARC2017 can be done on ``baxter@sheeta``.
 .. code-block:: bash
 
   # Launch nodes to control robot.
-  baxter@sheeta $ roslaunch jsk_arc2017_baxter baxter.launch
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter baxter.launch
 
   # Launch nodes in recognition pipeline for pick task.
-  baxter@sheeta $ roslaunch jsk_arc2017_baxter setup_for_pick.launch
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter setup_for_pick.launch
 
   # optional: Check sanity.
-  baxter@sheeta $ rosrun jsk_2016_01_baxter_apc check_sanity_setup_for_pick
+  baxter@baxter-c1 $ rosrun jsk_2016_01_baxter_apc check_sanity_setup_for_pick
 
   # Run task!
-  baxter@sheeta $ roslaunch jsk_arc2017_baxter pick.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_pick_task
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter pick.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_pick_task
 

--- a/doc/jsk_arc2017_baxter/arc2017_stow_trial.rst
+++ b/doc/jsk_arc2017_baxter/arc2017_stow_trial.rst
@@ -1,7 +1,7 @@
 ARC2017 Stow Task Trial on Real World
 =====================================
 
-Stow task trial on real world for ARC2017 can be done on ``baxter@sheeta``.
+Stow task trial on real world for ARC2017 can be done on ``baxter@baxter-c1``.
 
 - Prepare json.
 - Set objects in Tote.
@@ -9,11 +9,11 @@ Stow task trial on real world for ARC2017 can be done on ``baxter@sheeta``.
 .. code-block:: bash
 
   # Launch nodes to control robot.
-  baxter@sheeta $ roslaunch jsk_arc2017_baxter baxter.launch pick:=false
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter baxter.launch pick:=false
 
   # Launch nodes in recognition pipeline for stow task.
-  baxter@sheeta $ roslaunch jsk_arc2017_baxter setup_for_stow.launch
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter setup_for_stow.launch
 
   # Run task!
-  baxter@sheeta $ roslaunch jsk_arc2017_baxter stow.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_stow_task
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter stow.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_stow_task
 

--- a/doc/jsk_arc2017_baxter/state_machine.rst
+++ b/doc/jsk_arc2017_baxter/state_machine.rst
@@ -12,7 +12,7 @@ Pick Task
 .. code-block:: bash
 
   # Run pick task with smach_viewer
-  baxter@sheeta $ roslaunch jsk_arc2017_baxter pick.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_pick_task smach_viewer:=true
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter pick.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_pick_task smach_viewer:=true
 
 Stow Task
 ---------
@@ -22,4 +22,4 @@ Stow Task
 .. code-block:: bash
 
   # Run stow task with smach_viewer
-  baxter@sheeta $ roslaunch jsk_arc2017_baxter stow.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_stow_task smach_viewer:=true
+  baxter@baxter-c1 $ roslaunch jsk_arc2017_baxter stow.launch json_dir:=$(rospack find jsk_arc2017_common)/data/json/sample_stow_task smach_viewer:=true

--- a/jsk_arc2017_common/scripts/download_pick_re-experiment.py
+++ b/jsk_arc2017_common/scripts/download_pick_re-experiment.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import os.path as osp
+
+import jsk_data
+
+
+def main():
+    path = osp.expanduser('~/data/arc2017/system_inputs_jsons/pick_re-experiment.zip')  # NOQA
+    jsk_data.download_data(
+        pkg_name='jsk_arc2017_common',
+        path=path,
+        url='https://drive.google.com/uc?id=16ebONejvSC3j6Zp-6nAjQJqT-VLS7j5X',
+        md5='55e64309cf88bde3752874e8f6d6d60d',
+        extract=True,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/jsk_arc2017_common/scripts/install_pick_re-experiment
+++ b/jsk_arc2017_common/scripts/install_pick_re-experiment
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -x
+
+rosrun jsk_arc2017_common download_pick_re-experiment.py
+
+system_inputs=~/data/arc2017/system_inputs_jsons/pick_re-experiment/system_inputs
+
+ln -sf $system_inputs/objects/* $(rospack find jsk_arc2017_common)/data/objects/
+ln -sf $system_inputs/*.yaml $(rospack find jsk_arc2017_common)/config/
+ln -sf $system_inputs/FCN32s_iter00004800.npz $(rospack find jsk_arc2017_common)/data/models/fcn32s.npz
+
+set +x


### PR DESCRIPTION
I did the following:
1. Upload sharable ARC2017 data owned by @wkentaro to [google drive folder](https://drive.google.com/drive/folders/1fN2ZF-gvCromymyCBa1WzTHP6G4ym5tR) (accessible from [jsk_apc doc](https://jsk-apc.readthedocs.io/en/latest/jsk_arc2017_baxter/index.html#shared-data))
2. Add script to install pick_re-experiment (experiment imitating ARC2017 pick competition)
3. Add doc of how to execute pick_re-experiment

Other minor fix:
- Change sheeta to baxter-c1 in ARC2017 doc