### PR TITLE
Change FA-I-sensor to root repository in *.rosinstall

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,7 +1,7 @@
 - git:
     local-name: FA-I-sensor/force_proximity_ros
-    uri: https://github.com/knorth55/FA-I-sensor.git
-    version: jsk_apc
+    uri: https://github.com/RoboticMaterials/FA-I-sensor.git
+    version: master
 - git:
     local-name: RethinkRobotics/baxter_common
     uri: https://github.com/knorth55/baxter_common.git

--- a/fc.rosinstall.indigo
+++ b/fc.rosinstall.indigo
@@ -44,8 +44,8 @@
     version: gripper-v6-devel
 - git:
     local-name: FA-I-sensor/force_proximity_ros
-    uri: https://github.com/knorth55/FA-I-sensor.git
-    version: jsk_apc
+    uri: https://github.com/RoboticMaterials/FA-I-sensor.git
+    version: master
 - git:
     local-name: PointCloudLibrary/pcl
     uri: https://github.com/PointCloudLibrary/pcl.git

--- a/fc.rosinstall.kinetic
+++ b/fc.rosinstall.kinetic
@@ -56,8 +56,8 @@
     version: gripper-v6-devel
 - git:
     local-name: FA-I-sensor/force_proximity_ros
-    uri: https://github.com/knorth55/FA-I-sensor.git
-    version: jsk_apc
+    uri: https://github.com/RoboticMaterials/FA-I-sensor.git
+    version: master
 - tar:
     local-name: ros-planning/moveit_robots/baxter_moveit_config
     uri: https://github.com/ros-gbp/moveit_robots-release/archive/release/indigo/baxter_moveit_config/1.0.7-0.tar.gz

--- a/upboard.rosinstall
+++ b/upboard.rosinstall
@@ -8,5 +8,5 @@
     version: gripper-v6-devel
 - git:
     local-name: FA-I-sensor/force_proximity_ros
-    uri: https://github.com/knorth55/FA-I-sensor.git
-    version: jsk_apc
+    uri: https://github.com/RoboticMaterials/FA-I-sensor.git
+    version: master


### PR DESCRIPTION
Because https://github.com/RoboticMaterials/FA-I-sensor/pull/11 is merged