### PR TITLE
set opencv-python version to 4.2.0.32

### DIFF
--- a/demos/grasp_fusion/requirements.txt
+++ b/demos/grasp_fusion/requirements.txt
@@ -9,6 +9,7 @@ imgaug>=0.2.7
 labelme>=4.0.0
 matplotlib
 numpy
+opencv-python==4.2.0.32
 pathlib2
 Pillow
 PyYaml

--- a/demos/instance_occlsegm/requirements.txt
+++ b/demos/instance_occlsegm/requirements.txt
@@ -13,6 +13,7 @@ imgaug>=0.2.7
 labelme>=2.9
 matplotlib
 numpy
+opencv-python==4.2.0.32
 pathlib2
 Pillow
 pycocotools


### PR DESCRIPTION
opencv-python is no longer support python2.7.
I set to use `4.2.0.32` which is the last support version for python2.7
https://github.com/skvark/opencv-python/issues/152
https://github.com/skvark/opencv-python/releases/tag/34