### PR TITLE
disable CHECK_VENV in catkin_virtualenv 0.6.1

### DIFF
--- a/demos/grasp_fusion/ros/grasp_fusion/CMakeLists.txt
+++ b/demos/grasp_fusion/ros/grasp_fusion/CMakeLists.txt
@@ -28,6 +28,7 @@ catkin_package(
 )
 
 catkin_generate_virtualenv(
+  CHECK_VENV FALSE
   EXTRA_PIP_ARGS
     -qqq  # Suppress log not to exceed maximum length in travis test
     --upgrade

--- a/demos/grasp_prediction_arc2017/ros/grasp_prediction_arc2017/CMakeLists.txt
+++ b/demos/grasp_prediction_arc2017/ros/grasp_prediction_arc2017/CMakeLists.txt
@@ -28,6 +28,7 @@ catkin_package(
 )
 
 catkin_generate_virtualenv(
+  CHECK_VENV FALSE
   EXTRA_PIP_ARGS
     -qqq  # Suppress log not to exceed maximum length in travis test
     --upgrade

--- a/demos/instance_occlsegm/ros/instance_occlsegm/CMakeLists.txt
+++ b/demos/instance_occlsegm/ros/instance_occlsegm/CMakeLists.txt
@@ -106,6 +106,7 @@ catkin_package(
 )
 
 catkin_generate_virtualenv(
+  CHECK_VENV FALSE
   EXTRA_PIP_ARGS
     -qqq  # Suppress log not to exceed maximum length in travis test
     --upgrade


### PR DESCRIPTION
disable `CHECK_VENV` which causes build failure
https://github.com/locusrobotics/catkin_virtualenv/pull/62