### PR TITLE
fix dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,10 +34,9 @@ RUN cd ~ && \
     wstool merge start-jsk/jsk_apc/.travis.rosinstall.${ROS_DISTRO} && \
     wstool up -j 2
 
-RUN rosdep update --include-eol-distros
-
 # /opt/ros/${ROS_DISTRO}/share can be changed after rosdep install, so we run it 3 times.
-RUN for i in $(seq 3); do rosdep install --rosdistro ${ROS_DISTRO} -r -y -i --from-paths /opt/ros/${ROS_DISTRO}/share ~/ros/${ROS_DISTRO}/src; done && \
+RUN apt-get update && rosdep update --include-eol-distros && \
+    for i in $(seq 3); do rosdep install --rosdistro ${ROS_DISTRO} -r -y -i --from-paths /opt/ros/${ROS_DISTRO}/share ~/ros/${ROS_DISTRO}/src; done && \
     rm -rf /var/lib/apt/lists/*
 
 ARG TESTING


### PR DESCRIPTION
fix docker build in docker hub
we need to do `apt-get update` before `rosdep install` because we remove apt caches in ever layer for image size compression.