### PR TITLE
fix docker build for indigo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ jsk\_apc
 [![Gitter](https://badges.gitter.im/start-jsk/jsk_apc.svg)](https://gitter.im/start-jsk/jsk_apc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Slack](https://img.shields.io/badge/slack-%23jsk__apc-e100e1.svg)](https://jsk-robotics.slack.com/messages/jsk_apc/)
 [![Documentation Status](https://readthedocs.org/projects/jsk-apc/badge/?version=latest)](http://jsk-apc.readthedocs.org/en/latest/?badge=latest)
-[![Docker Build Status](https://img.shields.io/docker/build/jskrobotics/jsk_apc.svg)](https://hub.docker.com/r/jskrobotics/jsk_apc)
+[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/jskrobotics/jsk_apc)](https://hub.docker.com/r/jskrobotics/jsk_apc)
 **Forum** ([baxter](https://groups.google.com/a/jsk.imi.i.u-tokyo.ac.jp/forum/#!forum/baxter), [apc](https://groups.google.com/a/jsk.imi.i.u-tokyo.ac.jp/forum/#!forum/apc))
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN if [ ${ROS_DISTRO} = "indigo" ]; then \
     fi && \
     pip install 'pip==9.0.3' && \
     pip install 'setuptools==44.1.0' && \
+    pip install 'dlib==19.21.1' && \
     rm -rf /var/lib/apt/lists/*
 
 ARG ROS_DISTRO

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,17 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     python-pip && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install 'pip==9.0.3' && \
-    pip install 'setuptools==44.1.0'
+ARG ROS_DISTRO
+RUN if [ ${ROS_DISTRO} = "indigo" ]; then \
+      apt-get update && \
+      apt-get install -y software-properties-common && \
+      add-apt-repository -y ppa:longsleep/python2.7-backports && \
+      apt-get update && \
+      apt-get dist-upgrade -y; \
+    fi && \
+    pip install 'pip==9.0.3' && \
+    pip install 'setuptools==44.1.0' && \
+    rm -rf /var/lib/apt/lists/*
 
 ARG ROS_DISTRO
 RUN cd ~ && \


### PR DESCRIPTION
- update docker build badge in readme
- install python >=2.7.9 for indigo
  - because of non-SNI compatible client
  - related issue: https://github.com/pypa/pypi-support/issues/978
  - related website: https://status.python.org/incidents/hzmjhqsdjqgb
  - jsk_travis solution: https://github.com/jsk-ros-pkg/jsk_travis/commit/1acceab886c3c3e315ae7c057730566c938eafb5
- install `dlib<19.22` for indigo
  - dlib drop gcc 4.8 support
  - related issue: https://github.com/davisking/dlib/issues/2354