### PR TITLE
install moveit_robots from source

### DIFF
--- a/fc.rosinstall.melodic
+++ b/fc.rosinstall.melodic
@@ -51,10 +51,10 @@
     local-name: FA-I-sensor/force_proximity_ros
     uri: https://github.com/RoboticMaterials/FA-I-sensor.git
     version: master
-- tar:
-    local-name: ros-planning/moveit_robots/baxter_moveit_config
-    uri: https://github.com/ros-gbp/moveit_robots-release/archive/release/indigo/baxter_moveit_config/1.0.7-0.tar.gz
-    version: moveit_robots-release-release-indigo-baxter_moveit_config-1.0.7-0
+- git:
+    local-name: ros-planning/moveit_robots
+    uri: https://github.com/ros-planning/moveit_robots.git
+    version: kinetic-devel
 - git:
     local-name: turtlebot/turtlebot_description
     uri: https://github.com/turtlebot-release/turtlebot-release.git


### PR DESCRIPTION
latest moveit removes move_group/MoveGroupExecuteService

we need these commits.
https://github.com/ros-planning/moveit_robots/commit/707b86b43ba2a0bda1d27ce2019f798d9d79005a
https://github.com/ros-planning/moveit_robots/commit/3514d389b45361b19af936099af45090912ec1f1