### PR TITLE
update .travis.rosinstall for kinetic and melodic

### DIFF
--- a/.github/workflows/indigo.yaml
+++ b/.github/workflows/indigo.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
+          sudo git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME

--- a/.github/workflows/indigo.yaml
+++ b/.github/workflows/indigo.yaml
@@ -45,7 +45,7 @@ jobs:
           NOT_TEST_INSTALL: true
           ROSDEP_ADDITIONAL_OPTIONS: "-n -q --ignore-src --skip-keys=jsk_smart_gui --skip-keys=ros3djs --skip-keys=pr2_calibration_launch --skip-keys=jsk_android_gui_api9 --skip-keys=ros2djs --skip-keys=face_recognition --skip-keys=roslibjs --skip-keys=force_proximity_ros --skip-keys=safe_teleop_base --skip-keys=pcl"
           # XXX: hotfix for chainer problem (https://github.com/chainer/chainer/issues/8545)
-          BEFORE_SCRIPT: "sudo -H pip install -U numpy fcn chainercv chainer==6.7.0 gdown==4.4.0 scikit-learn==0.19.1"
+          BEFORE_SCRIPT: "sudo -H pip install -U numpy fcn chainercv chainer==6.7.0 gdown==4.4.0 scikit-learn==0.19.1 protobuf==3.18.0"
           CATKIN_TOOLS_CONFIG_OPTIONS: "--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop"
           # instance_occlsegm and grasp_fusion are excluded because of gdrive download maximum trials.
           # see: https://github.com/start-jsk/jsk_apc/pull/2745

--- a/.github/workflows/indigo.yaml
+++ b/.github/workflows/indigo.yaml
@@ -45,7 +45,7 @@ jobs:
           NOT_TEST_INSTALL: true
           ROSDEP_ADDITIONAL_OPTIONS: "-n -q --ignore-src --skip-keys=jsk_smart_gui --skip-keys=ros3djs --skip-keys=pr2_calibration_launch --skip-keys=jsk_android_gui_api9 --skip-keys=ros2djs --skip-keys=face_recognition --skip-keys=roslibjs --skip-keys=force_proximity_ros --skip-keys=safe_teleop_base --skip-keys=pcl"
           # XXX: hotfix for chainer problem (https://github.com/chainer/chainer/issues/8545)
-          BEFORE_SCRIPT: "sudo -H pip install -U numpy fcn chainercv chainer==6.7.0 gdown==4.4.0 scikit-learn==0.19.1 protobuf==3.18.0"
+          BEFORE_SCRIPT: "sudo -H pip install -U numpy fcn chainercv chainer==6.7.0 gdown==4.4.0 scikit-learn==0.19.1 protobuf==3.17.3"
           CATKIN_TOOLS_CONFIG_OPTIONS: "--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop"
           # instance_occlsegm and grasp_fusion are excluded because of gdrive download maximum trials.
           # see: https://github.com/start-jsk/jsk_apc/pull/2745

--- a/.github/workflows/indigo.yaml
+++ b/.github/workflows/indigo.yaml
@@ -15,10 +15,10 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          sudo git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
       - name: Checkout
         uses: actions/checkout@v2
       # github actions cache does not work because of permission denied.
@@ -32,6 +32,10 @@ jobs:
       #       ~/apt-cacher-ng
       #       ~/.ros/data
       #     key: ${{ github.workflow }}
+      - name: work around permission issue again
+        run: |
+          set -x
+          grep path $GITHUB_WORKSPACE/.gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $GITHUB_WORKSPACE/'{}'
       - name: Run jsk_travis
         uses: jsk-ros-pkg/jsk_travis@master
         with:

--- a/.github/workflows/indigo.yaml
+++ b/.github/workflows/indigo.yaml
@@ -11,8 +11,14 @@ jobs:
     steps:
       - name: Install latest git (use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
         run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
-      - name: Before Checkout # need for actions/checkout with ros-ubuntu container
-        run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
+      - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
+        run: |
+          set -x
+          export USER=$(whoami)
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
+          sudo mkdir -p /__w/
+          sudo chmod 777 -R /__w/
+          sudo chown -R $USER $HOME
       - name: Checkout
         uses: actions/checkout@v2
       # github actions cache does not work because of permission denied.

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
+          sudo git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -45,7 +45,7 @@ jobs:
           NOT_TEST_INSTALL: true
           ROSDEP_ADDITIONAL_OPTIONS: "-n -q --ignore-src --skip-keys=jsk_smart_gui --skip-keys=ros3djs --skip-keys=pr2_calibration_launch --skip-keys=jsk_android_gui_api9 --skip-keys=ros2djs --skip-keys=face_recognition --skip-keys=roslibjs --skip-keys=force_proximity_ros --skip-keys=safe_teleop_base --skip-keys=pcl"
           # XXX: hotfix for chainer problem (https://github.com/chainer/chainer/issues/8545)
-          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0"
+          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0 protobuf==3.18.0"
           CATKIN_TOOLS_CONFIG_OPTIONS: "--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop test_catkin_virtualenv test_catkin_virtualenv_py3_isolated test_catkin_virtualenv_inherited"
           # instance_occlsegm and grasp_fusion are excluded because of gdrive download maximum trials.
           # see: https://github.com/start-jsk/jsk_apc/pull/2745

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -15,10 +15,10 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          sudo git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
       - name: Checkout
         uses: actions/checkout@v2
       # github actions cache does not work because of permission denied.
@@ -32,6 +32,10 @@ jobs:
       #       ~/apt-cacher-ng
       #       ~/.ros/data
       #     key: ${{ github.workflow }}
+      - name: work around permission issue again
+        run: |
+          set -x
+          grep path $GITHUB_WORKSPACE/.gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $GITHUB_WORKSPACE/'{}'
       - name: Run jsk_travis
         uses: jsk-ros-pkg/jsk_travis@master
         with:

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -45,7 +45,7 @@ jobs:
           NOT_TEST_INSTALL: true
           ROSDEP_ADDITIONAL_OPTIONS: "-n -q --ignore-src --skip-keys=jsk_smart_gui --skip-keys=ros3djs --skip-keys=pr2_calibration_launch --skip-keys=jsk_android_gui_api9 --skip-keys=ros2djs --skip-keys=face_recognition --skip-keys=roslibjs --skip-keys=force_proximity_ros --skip-keys=safe_teleop_base --skip-keys=pcl"
           # XXX: hotfix for chainer problem (https://github.com/chainer/chainer/issues/8545)
-          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0 protobuf==3.18.0"
+          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0 protobuf==3.17.3"
           CATKIN_TOOLS_CONFIG_OPTIONS: "--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop test_catkin_virtualenv test_catkin_virtualenv_py3_isolated test_catkin_virtualenv_inherited"
           # instance_occlsegm and grasp_fusion are excluded because of gdrive download maximum trials.
           # see: https://github.com/start-jsk/jsk_apc/pull/2745

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -11,8 +11,14 @@ jobs:
     steps:
       - name: Install latest git (use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
         run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
-      - name: Before Checkout # need for actions/checkout with ros-ubuntu container
-        run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
+      - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
+        run: |
+          set -x
+          export USER=$(whoami)
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
+          sudo mkdir -p /__w/
+          sudo chmod 777 -R /__w/
+          sudo chown -R $USER $HOME
       - name: Checkout
         uses: actions/checkout@v2
       # github actions cache does not work because of permission denied.

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -45,7 +45,7 @@ jobs:
           NOT_TEST_INSTALL: true
           ROSDEP_ADDITIONAL_OPTIONS: "-n -q --ignore-src --skip-keys=jsk_smart_gui --skip-keys=ros3djs --skip-keys=pr2_calibration_launch --skip-keys=jsk_android_gui_api9 --skip-keys=ros2djs --skip-keys=face_recognition --skip-keys=roslibjs --skip-keys=force_proximity_ros --skip-keys=safe_teleop_base --skip-keys=pcl"
           # XXX: hotfix for chainer problem (https://github.com/chainer/chainer/issues/8545)
-          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0 protobuf==3.18.0"
+          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0 protobuf==3.17.3"
           CATKIN_TOOLS_CONFIG_OPTIONS: "--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop"
           # instance_occlsegm and grasp_fusion are excluded because of gdrive download maximum trials.
           # see: https://github.com/start-jsk/jsk_apc/pull/2745

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
+          sudo git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -15,10 +15,10 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          sudo git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
       - name: Checkout
         uses: actions/checkout@v2
       # github actions cache does not work because of permission denied.
@@ -32,6 +32,10 @@ jobs:
       #       ~/apt-cacher-ng
       #       ~/.ros/data
       #     key: ${{ github.workflow }}
+      - name: work around permission issue again
+        run: |
+          set -x
+          grep path $GITHUB_WORKSPACE/.gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $GITHUB_WORKSPACE/'{}'
       - name: Run jsk_travis
         uses: jsk-ros-pkg/jsk_travis@master
         with:

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -45,7 +45,7 @@ jobs:
           NOT_TEST_INSTALL: true
           ROSDEP_ADDITIONAL_OPTIONS: "-n -q --ignore-src --skip-keys=jsk_smart_gui --skip-keys=ros3djs --skip-keys=pr2_calibration_launch --skip-keys=jsk_android_gui_api9 --skip-keys=ros2djs --skip-keys=face_recognition --skip-keys=roslibjs --skip-keys=force_proximity_ros --skip-keys=safe_teleop_base --skip-keys=pcl"
           # XXX: hotfix for chainer problem (https://github.com/chainer/chainer/issues/8545)
-          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0"
+          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0 protobuf==3.18.0"
           CATKIN_TOOLS_CONFIG_OPTIONS: "--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop"
           # instance_occlsegm and grasp_fusion are excluded because of gdrive download maximum trials.
           # see: https://github.com/start-jsk/jsk_apc/pull/2745

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -11,8 +11,14 @@ jobs:
     steps:
       - name: Install latest git (use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
         run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
-      - name: Before Checkout # need for actions/checkout with ros-ubuntu container
-        run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
+      - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
+        run: |
+          set -x
+          export USER=$(whoami)
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
+          sudo mkdir -p /__w/
+          sudo chmod 777 -R /__w/
+          sudo chown -R $USER $HOME
       - name: Checkout
         uses: actions/checkout@v2
       # github actions cache does not work because of permission denied.

--- a/.github/workflows/python2.yml
+++ b/.github/workflows/python2.yml
@@ -1,0 +1,17 @@
+# jsk_travis
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: check_python2
+
+    container: ubuntu:20.04
+
+    steps:
+      - name: Chcekout
+        uses: actions/checkout@v2
+      - name: Check Python2
+        run: |
+          apt update -q && apt install -y -q python2
+          python2 -m compileall .

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -50,5 +50,5 @@
 # https://github.com/locusrobotics/catkin_virtualenv/pull/85
 - git:
     local-name: catkin_virtualenv
-    uri: https://github.com/knorth55/catkin_virtualenv.git
-    version: rospkg-bump
+    uri: https://github.com/locusrobotics/catkin_virtualenv.git
+    version: 24ab7433e3e98a3ad4c7f3b29960026d858b73bf

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -52,5 +52,5 @@
 # https://github.com/locusrobotics/catkin_virtualenv/pull/85
 - git:
     local-name: catkin_virtualenv
-    uri: https://github.com/knorth55/catkin_virtualenv.git
-    version: rospkg-bump
+    uri: https://github.com/locusrobotics/catkin_virtualenv.git
+    version: 24ab7433e3e98a3ad4c7f3b29960026d858b73bf

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,15 @@ env:
     - >
       ROS_DISTRO=indigo
       BUILD_PKGS="jsk_apc2015_common jsk_apc2016_common jsk_arc2017_common jsk_2015_05_baxter_apc jsk_2016_01_baxter_apc jsk_arc2017_baxter selective_dualarm_stowing sphand_driver sphand_driver_msgs vl53l0x_mraa_ros baxtergv6_apc2016 baxter_paper_filing"
-      BEFORE_SCRIPT='sudo -H pip install chainer==6.7.0 gdown==4.4.0 scikit-learn==0.19.1'
+      BEFORE_SCRIPT='sudo -H pip install chainer==6.7.0 gdown==4.4.0 scikit-learn==0.19.1 protobuf==3.18.0'
       CATKIN_TOOLS_CONFIG_OPTIONS="--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop"
     - >
       ROS_DISTRO=kinetic
-      BEFORE_SCRIPT='sudo -H pip install chainer==6.7.0 gdown==4.4.0'
+      BEFORE_SCRIPT='sudo -H pip install chainer==6.7.0 gdown==4.4.0 protobuf==3.18.0'
       CATKIN_TOOLS_CONFIG_OPTIONS="--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop test_catkin_virtualenv test_catkin_virtualenv_py3_isolated test_catkin_virtualenv_inherited"
     - >
       ROS_DISTRO=melodic
-      BEFORE_SCRIPT='sudo -H pip install chainer==6.7.0 gdown==4.4.0'
+      BEFORE_SCRIPT='sudo -H pip install chainer==6.7.0 gdown==4.4.0 protobuf==3.18.0'
       CATKIN_TOOLS_CONFIG_OPTIONS="--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop"
 matrix:
   allow_failures:

--- a/demos/grasp_fusion/requirements.txt
+++ b/demos/grasp_fusion/requirements.txt
@@ -12,6 +12,7 @@ numpy
 opencv-python==4.2.0.32
 pathlib2
 Pillow
+protobuf==3.18.0
 PyYaml
 scipy>=1.0.0
 scikit-image

--- a/demos/grasp_fusion/requirements.txt
+++ b/demos/grasp_fusion/requirements.txt
@@ -12,7 +12,7 @@ numpy
 opencv-python==4.2.0.32
 pathlib2
 Pillow
-protobuf==3.18.0
+protobuf==3.17.3
 PyYaml
 scipy>=1.0.0
 scikit-image

--- a/demos/instance_occlsegm/requirements.txt
+++ b/demos/instance_occlsegm/requirements.txt
@@ -16,6 +16,7 @@ numpy
 opencv-python==4.2.0.32
 pathlib2
 Pillow
+protobuf==3.18.0
 pycocotools
 PyYaml
 scipy>=1.0.0

--- a/demos/instance_occlsegm/requirements.txt
+++ b/demos/instance_occlsegm/requirements.txt
@@ -16,7 +16,7 @@ numpy
 opencv-python==4.2.0.32
 pathlib2
 Pillow
-protobuf==3.18.0
+protobuf==3.17.3
 pycocotools
 PyYaml
 scipy>=1.0.0


### PR DESCRIPTION
this PR is from #2746 

- use latest catkin_virtualenv
  - https://github.com/locusrobotics/catkin_virtualenv/pull/85 is merged, we can use the origin/master branch
- fix permission issue reported in https://github.com/jsk-ros-pkg/jsk_travis/pull/445
- fix protobuf version
- add python2 syntax test