### PR TITLE
[CI] Update jsk_travis to 0.5.25 & fix permission error

### DIFF
--- a/.github/workflows/indigo.yaml
+++ b/.github/workflows/indigo.yaml
@@ -45,7 +45,7 @@ jobs:
           NOT_TEST_INSTALL: true
           ROSDEP_ADDITIONAL_OPTIONS: "-n -q --ignore-src --skip-keys=jsk_smart_gui --skip-keys=ros3djs --skip-keys=pr2_calibration_launch --skip-keys=jsk_android_gui_api9 --skip-keys=ros2djs --skip-keys=face_recognition --skip-keys=roslibjs --skip-keys=force_proximity_ros --skip-keys=safe_teleop_base --skip-keys=pcl"
           # XXX: hotfix for chainer problem (https://github.com/chainer/chainer/issues/8545)
-          BEFORE_SCRIPT: "sudo -H pip install -U numpy fcn chainercv chainer==6.7.0 gdown==4.4.0 scikit-learn==0.19.1"
+          BEFORE_SCRIPT: "sudo -H pip install -U numpy fcn chainercv chainer==6.7.0 gdown==4.4.0 scikit-learn==0.19.1 protobuf==3.17.3"
           CATKIN_TOOLS_CONFIG_OPTIONS: "--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop"
           # instance_occlsegm and grasp_fusion are excluded because of gdrive download maximum trials.
           # see: https://github.com/start-jsk/jsk_apc/pull/2745

--- a/.github/workflows/indigo.yaml
+++ b/.github/workflows/indigo.yaml
@@ -14,7 +14,9 @@ jobs:
       - name: Before Checkout # need for actions/checkout with ros-ubuntu container
         run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
+        with:
+          submodules: true
       # github actions cache does not work because of permission denied.
       # see: https://github.com/actions/cache/issues/404
       # - name: Cache several data

--- a/.github/workflows/indigo.yaml
+++ b/.github/workflows/indigo.yaml
@@ -10,9 +10,17 @@ jobs:
 
     steps:
       - name: Install latest git (use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
-      - name: Before Checkout # need for actions/checkout with ros-ubuntu container
-        run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
+        run: |
+          (apt-get update && apt-get install -y sudo) || echo "OK"
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+      - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
+        run: |
+          set -x
+          export USER=$(whoami)
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
+          sudo mkdir -p /__w/
+          sudo chmod 777 -R /__w/
+          sudo chown -R $USER $HOME
       - name: Checkout
         uses: actions/checkout@v3.0.2
         with:

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -45,7 +45,7 @@ jobs:
           NOT_TEST_INSTALL: true
           ROSDEP_ADDITIONAL_OPTIONS: "-n -q --ignore-src --skip-keys=jsk_smart_gui --skip-keys=ros3djs --skip-keys=pr2_calibration_launch --skip-keys=jsk_android_gui_api9 --skip-keys=ros2djs --skip-keys=face_recognition --skip-keys=roslibjs --skip-keys=force_proximity_ros --skip-keys=safe_teleop_base --skip-keys=pcl"
           # XXX: hotfix for chainer problem (https://github.com/chainer/chainer/issues/8545)
-          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0"
+          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0 protobuf==3.17.3"
           CATKIN_TOOLS_CONFIG_OPTIONS: "--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop test_catkin_virtualenv test_catkin_virtualenv_py3_isolated test_catkin_virtualenv_inherited"
           # instance_occlsegm and grasp_fusion are excluded because of gdrive download maximum trials.
           # see: https://github.com/start-jsk/jsk_apc/pull/2745

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Before Checkout # need for actions/checkout with ros-ubuntu container
         run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
+        with:
+          submodules: true
       # github actions cache does not work because of permission denied.
       # see: https://github.com/actions/cache/issues/404
       # - name: Cache several data

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -6,13 +6,21 @@ jobs:
     runs-on: ubuntu-latest
     name: kinetic
 
-    container: jskrobotics/ros-ubuntu:16.04
+    container: ubuntu:16.04
 
     steps:
       - name: Install latest git (use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
-      - name: Before Checkout # need for actions/checkout with ros-ubuntu container
-        run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
+        run: |
+          (apt-get update && apt-get install -y sudo) || echo "OK"
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+      - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
+        run: |
+          set -x
+          export USER=$(whoami)
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
+          sudo mkdir -p /__w/
+          sudo chmod 777 -R /__w/
+          sudo chown -R $USER $HOME
       - name: Checkout
         uses: actions/checkout@v3.0.2
         with:

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Before Checkout # need for actions/checkout with ros-ubuntu container
         run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
+        with:
+          submodules: true
       # github actions cache does not work because of permission denied.
       # see: https://github.com/actions/cache/issues/404
       # - name: Cache several data

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -6,13 +6,21 @@ jobs:
     runs-on: ubuntu-latest
     name: melodic
 
-    container: jskrobotics/ros-ubuntu:18.04
+    container: ubuntu:18.04
 
     steps:
       - name: Install latest git (use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
-      - name: Before Checkout # need for actions/checkout with ros-ubuntu container
-        run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
+        run: |
+          (apt-get update && apt-get install -y sudo) || echo "OK"
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+      - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
+        run: |
+          set -x
+          export USER=$(whoami)
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
+          sudo mkdir -p /__w/
+          sudo chmod 777 -R /__w/
+          sudo chown -R $USER $HOME
       - name: Checkout
         uses: actions/checkout@v3.0.2
         with:

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -45,7 +45,7 @@ jobs:
           NOT_TEST_INSTALL: true
           ROSDEP_ADDITIONAL_OPTIONS: "-n -q --ignore-src --skip-keys=jsk_smart_gui --skip-keys=ros3djs --skip-keys=pr2_calibration_launch --skip-keys=jsk_android_gui_api9 --skip-keys=ros2djs --skip-keys=face_recognition --skip-keys=roslibjs --skip-keys=force_proximity_ros --skip-keys=safe_teleop_base --skip-keys=pcl"
           # XXX: hotfix for chainer problem (https://github.com/chainer/chainer/issues/8545)
-          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0"
+          BEFORE_SCRIPT: "sudo -H pip install fcn chainercv chainer==6.7.0 gdown==4.4.0 protobuf==3.17.3"
           CATKIN_TOOLS_CONFIG_OPTIONS: "--blacklist imagesift jsk_recognition_msgs jsk_perception jsk_pcl_ros_utils jsk_pcl_ros resized_image_transport checkerboard_detector fetcheus naoqieus jsk_fetch_startup jsk_nao_startup roseus_remote jsk_robot_startup jsk_robot_utils jsk_pr2_calibration pr2_base_trajectory_action jsk_baxter_web peppereus naoeus jsk_baxter_desktop jsk_pepper_startup jsk_pr2_startup jsk_pr2_desktop"
           # instance_occlsegm and grasp_fusion are excluded because of gdrive download maximum trials.
           # see: https://github.com/start-jsk/jsk_apc/pull/2745


### PR DESCRIPTION
CI of #2761 failed with `Error: EACCES: permission denied`:
https://github.com/start-jsk/jsk_apc/actions/runs/4645724979/jobs/8262808792?pr=2761

This PR tries to fix that by the same solution as https://github.com/start-jsk/rtmros_tutorials/pull/616 and https://github.com/start-jsk/rtmros_tutorials/commit/a1459f2189b26a79b6ce39e99ee6ad82fb982a31.